### PR TITLE
Add a few minor tweaks

### DIFF
--- a/4.5.4/Dockerfile
+++ b/4.5.4/Dockerfile
@@ -1,7 +1,6 @@
 FROM java:openjdk-8u45-jre
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 
-ENV SONAR_VERSION 4.5.4
 ENV SONAR_HOME /opt/sonarqube
 EXPOSE 9000 9092
 
@@ -10,12 +9,24 @@ ENV SONARQUBE_JDBC_USERNAME sonar
 ENV SONARQUBE_JDBC_PASSWORD sonar
 ENV SONARQUBE_JDBC_URL jdbc:h2:tcp://localhost:9092/sonar
 
-RUN cd /opt \
-	&& curl -o sonarqube.zip http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip \
+# pub   4096R/F0EA05E3 2014-06-25 [expires: 2019-06-24]
+#       Key fingerprint = E5C6 7B40 77AD A450 D209  2D4D 2B2E E179 F0EA 05E3
+# uid                  Thomas Vérin <thomas.verin@sonarsource.com>
+# sub   4096R/A0D97B83 2014-06-25 [expires: 2019-06-24]
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys E5C67B4077ADA450D2092D4D2B2EE179F0EA05E3
+
+ENV SONAR_VERSION 4.5.4
+
+RUN set -x \
+	&& cd /opt \
+	&& curl -o sonarqube.zip -fSL http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip \
+	&& curl -o sonarqube.zip.asc -fSL http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip.asc \
+	&& gpg --verify sonarqube.zip.asc \
 	&& unzip sonarqube.zip \
 	&& mv sonarqube-$SONAR_VERSION sonarqube \
-	&& rm sonarqube.zip \
+	&& rm sonarqube.zip* \
 	&& rm -rf $SONAR_HOME/bin/*
 
-COPY run.sh $SONAR_HOME/bin/run.sh
-CMD $SONAR_HOME/bin/run.sh
+COPY run.sh $SONAR_HOME/bin/
+WORKDIR $SONAR_HOME
+CMD ["./bin/run.sh"]

--- a/4.5.4/run.sh
+++ b/4.5.4/run.sh
@@ -5,9 +5,7 @@ IFS=$'\n\t'
 
 echo Running SonarQube [$SONAR_VERSION]
 
-cd $SONAR_HOME
-
-java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -1,7 +1,6 @@
 FROM java:openjdk-8u45-jre
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 
-ENV SONAR_VERSION 5.1
 ENV SONAR_HOME /opt/sonarqube
 EXPOSE 9000 9092
 
@@ -10,12 +9,24 @@ ENV SONARQUBE_JDBC_USERNAME sonar
 ENV SONARQUBE_JDBC_PASSWORD sonar
 ENV SONARQUBE_JDBC_URL jdbc:h2:tcp://localhost:9092/sonar
 
-RUN cd /opt \
-	&& curl -o sonarqube.zip http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip \
+# pub   2048R/0C1F120F 2015-03-19
+#       Key fingerprint = F19F 217F A669 DEFA 9E51  4B64 F67E 93C6 0C1F 120F
+# uid                  sonartech <sonartech@sonarsource.com>
+# sub   2048R/5C6BEEA6 2015-03-19
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F19F217FA669DEFA9E514B64F67E93C60C1F120F
+
+ENV SONAR_VERSION 5.1
+
+RUN set -x \
+	&& cd /opt \
+	&& curl -o sonarqube.zip -fSL http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip \
+	&& curl -o sonarqube.zip.asc -fSL http://dist.sonar.codehaus.org/sonarqube-$SONAR_VERSION.zip.asc \
+	&& gpg --verify sonarqube.zip.asc \
 	&& unzip sonarqube.zip \
 	&& mv sonarqube-$SONAR_VERSION sonarqube \
-	&& rm sonarqube.zip \
+	&& rm sonarqube.zip* \
 	&& rm -rf $SONAR_HOME/bin/*
 
-COPY run.sh $SONAR_HOME/bin/run.sh
-CMD $SONAR_HOME/bin/run.sh
+COPY run.sh $SONAR_HOME/bin/
+WORKDIR $SONAR_HOME
+CMD ["./bin/run.sh"]

--- a/5.1/run.sh
+++ b/5.1/run.sh
@@ -5,9 +5,7 @@ IFS=$'\n\t'
 
 echo Running SonarQube [$SONAR_VERSION]
 
-cd $SONAR_HOME
-
-java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \


### PR DESCRIPTION
- verify downloaded file PGP signatures (since signatures are available)
- reorder instructions a little for better cache overlap (shared layers between the two versions)
- utilize `WORKDIR` to make `run.sh` slightly simpler and allow the JSON syntax for `CMD` which avoids an extra `sh` process
- utilize `exec` in `run.sh` to avoid a second extra `sh` process (which makes `java` become "pid 1" in the container, instead of the shell -- see `docker top <running-container>`)