### PR TITLE
Let the user set JVM and launch parameters

### DIFF
--- a/4.5.4/run.sh
+++ b/4.5.4/run.sh
@@ -5,10 +5,10 @@ if [ "${1:0:1}" != '-' ]; then
 	exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java $JAVA_OPTS -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
   -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom" \
-	"$@"
+	$SONAR_OPTS "$@"

--- a/5.1/run.sh
+++ b/5.1/run.sh
@@ -5,10 +5,10 @@ if [ "${1:0:1}" != '-' ]; then
 	exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java $JAVA_OPTS -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
   -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom" \
-	"$@"
+	$SONAR_OPTS "$@"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ The production database is configured with theses variables:
 
 More recipes can be found [here](https://github.com/SonarSource/docker-sonarqube/blob/master/recipes.md)
 
+## Passing JVM and SonarQube launcher parameters
+
+You might need to customize the JVM running SonarQube, typically to pass system properties or tweak heap memory settings.
+Use JAVA_OPTS environment variable for this purpose:
+
+    docker run --name sonarqube -p 9000:9000 --env JAVA_OPTS=-Dsonar.web.context=/sonarqube sonarqube:5.1
+
+You also can define sonar arguments as SONAR_OPTS.
+
 ## Administration
 
 The administration guide can be found [here](http://docs.sonarqube.org/display/SONAR/Administration+Guide).


### PR DESCRIPTION
I am running SonarQube behind a reverse proxy and thus that i need a simple solution to set the system property to change the web context:
docker run --name sonarqube -p 9000:9000 --env JAVA_OPTS=-Dsonar.web.context=/sonarqube sonarqube:5.1