### PR TITLE
Add VOLUME instruction to persist data and extentions.

### DIFF
--- a/4.5.4/Dockerfile
+++ b/4.5.4/Dockerfile
@@ -34,6 +34,8 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
 ENTRYPOINT ["./bin/run.sh"]

--- a/5.1.1/Dockerfile
+++ b/5.1.1/Dockerfile
@@ -34,6 +34,8 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
 ENTRYPOINT ["./bin/run.sh"]

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -34,6 +34,8 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
 ENTRYPOINT ["./bin/run.sh"]


### PR DESCRIPTION
Using Docker Compose, the plugins where uninstalled when using `docker-compose up` for the second time. Please see [this question on SO](http://stackoverflow.com/questions/31288681/sonar-qualityprofile-page-does-not-display-correctly-using-docker-when-data-volu/31324401).

Adding a VOLUME instruction also allows to do backups [like described in the docker documentation](https://docs.docker.com/userguide/dockervolumes/#backup-restore-or-migrate-data-volumes).