### PR TITLE
Fix NPE when Generating chart

### DIFF
--- a/5.1.1/Dockerfile
+++ b/5.1.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8u45-jre
+FROM java:openjdk-8u45-jdk
 
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 


### PR DESCRIPTION
Use JDK as with JRE a NPE is raised upon chart generation e.g. when
viewing TimeMachine. Full Stack trace:

2015.07.14 20:56:34 ERROR web[o.s.s.c.ChartsServlet] Generating chart
org.sonar.server.charts.deprecated.SparkLinesChart
java.lang.NullPointerException: null
	at sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
~[na:1.8.0_45-internal]
	at
sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:219)
~[na:1.8.0_45-internal]
	at sun.awt.FontConfiguration.init(FontConfiguration.java:107)
~[na:1.8.0_45-internal]
	at
sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:776)
~[na:1.8.0_45-internal]
	at sun.font.SunFontManager$2.run(SunFontManager.java:431)
~[na:1.8.0_45-internal]
	at java.security.AccessController.doPrivileged(Native Method)
~[na:1.8.0_45-internal]
	at sun.font.SunFontManager.<init>(SunFontManager.java:376)
~[na:1.8.0_45-internal]
	at sun.awt.X11FontManager.<init>(X11FontManager.java:57)
~[na:1.8.0_45-internal]
	at sun.reflect.GeneratedConstructorAccessor63.newInstance(Unknown
Source) ~[na:na]
	at
sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
~[na:1.8.0_45-internal]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
~[na:1.8.0_45-internal]
	at java.lang.Class.newInstance(Class.java:442) ~[na:1.8.0_45-internal]
	at sun.font.FontManagerFactory$1.run(FontManagerFactory.java:83)
~[na:1.8.0_45-internal]
	at java.security.AccessController.doPrivileged(Native Method)
~[na:1.8.0_45-internal]
	at sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:74)
~[na:1.8.0_45-internal]
	at java.awt.Font.getFont2D(Font.java:491) ~[na:1.8.0_45-internal]
	at java.awt.Font.defaultLineMetrics(Font.java:2176)
~[na:1.8.0_45-internal]
	at java.awt.Font.getLineMetrics(Font.java:2246) ~[na:1.8.0_45-internal]
	at
org.jfree.chart.axis.NumberAxis.estimateMaximumTickLabelHeight(NumberAxis.java:974)
~[jfreechart-1.0.9.jar:na]
	at
org.jfree.chart.axis.NumberAxis.selectVerticalAutoTickUnit(NumberAxis.java:1104)
~[jfreechart-1.0.9.jar:na]
	at
org.jfree.chart.axis.NumberAxis.selectAutoTickUnit(NumberAxis.java:1048)
~[jfreechart-1.0.9.jar:na]
	at
org.jfree.chart.axis.NumberAxis.refreshTicksVertical(NumberAxis.java:1249)
~[jfreechart-1.0.9.jar:na]
	at org.jfree.chart.axis.NumberAxis.refreshTicks(NumberAxis.java:1149)
~[jfreechart-1.0.9.jar:na]
	at org.jfree.chart.axis.NumberAxis.draw(NumberAxis.java:659)
~[jfreechart-1.0.9.jar:na]
	at org.jfree.chart.plot.XYPlot.drawAxes(XYPlot.java:3151)
~[jfreechart-1.0.9.jar:na]
	at org.jfree.chart.plot.XYPlot.draw(XYPlot.java:2666)
~[jfreechart-1.0.9.jar:na]
	at org.jfree.chart.JFreeChart.draw(JFreeChart.java:1222)
~[jfreechart-1.0.9.jar:na]
	at org.jfree.chart.JFreeChart.createBufferedImage(JFreeChart.java:1396)
~[jfreechart-1.0.9.jar:na]
	at
org.sonar.server.charts.deprecated.BaseChart.getBufferedImage(BaseChart.java:114)
~[sonar-server-5.1.1.jar:na]
	at
org.sonar.server.charts.deprecated.SparkLinesChart.getChartImage(SparkLinesChart.java:53)
~[sonar-server-5.1.1.jar:na]
	at
org.sonar.server.charts.deprecated.BaseChart.exportChartAsPNG(BaseChart.java:120)
~[sonar-server-5.1.1.jar:na]
	at
org.sonar.server.charts.ChartsServlet.deprecatedDoGet(ChartsServlet.java:152)
[sonar-server-5.1.1.jar:na]
	at org.sonar.server.charts.ChartsServlet.doGet(ChartsServlet.java:56)
[sonar-server-5.1.1.jar:na]