### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ docker-sonarqube
 # Supported tags and respective Dockerfile links
 
 * `5.1`, `latest` ([Dockerfile](https://github.com/SonarSource/docker-sonarqube/blob/master/5.1/Dockerfile))
-* `4.5.4`, `lts` ([Dockerfile](https://github.com/SonarSource/docker-sonarqube/blob/master/5.1/Dockerfile))
+* `4.5.4`, `lts` ([Dockerfile](https://github.com/SonarSource/docker-sonarqube/blob/master/4.5.4/Dockerfile))
 
 For more information about this image and its history, please see the
 [relevant manifest file](https://github.com/docker-library/official-images/blob/master/library/sonarqube) (`library/sonarqube`) in the `docker-library/official-images` [GitHub repo](https://github.com/docker-library/official-images).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ docker-sonarqube
 
 # Supported tags and respective Dockerfile links
 
-* `5.1`, `latest` ([Dockerfile](https://github.com/SonarSource/docker-sonarqube/blob/master/5.1/Dockerfile))
+* `5.1.2`, `latest` ([Dockerfile](https://github.com/SonarSource/docker-sonarqube/blob/master/5.1.2/Dockerfile))
 * `4.5.4`, `lts` ([Dockerfile](https://github.com/SonarSource/docker-sonarqube/blob/master/4.5.4/Dockerfile))
 
 For more information about this image and its history, please see the


### PR DESCRIPTION
Small fixes in README.

Otherwise, dunno why there isn't any image in version 4.5.5 in DockerHub ?