### PR TITLE
dont stick with old version of jdk

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8u45-jdk
+FROM java:8
 
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 
@@ -23,8 +23,8 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBC
 
 RUN set -x \
 	&& cd /opt \
-	&& curl -o sonarqube.zip -fSL https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \
-	&& curl -o sonarqube.zip.asc -fSL https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip.asc \
+	&& wget -q -O sonarqube.zip https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \
+	&& wget -q -O sonarqube.zip.asc https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip.asc \
 	&& gpg --verify sonarqube.zip.asc \
 	&& unzip sonarqube.zip \
 	&& mv sonarqube-$SONAR_VERSION sonarqube \


### PR DESCRIPTION
Changed version of of jdk to  latest 8. Due to ssl problems I had to replace curl with wget.

If this is fine to you, plz change the other versions as well!

I rate this is as structural security improvement.

Cheers Lars