### PR TITLE
Remove sonar.web.javaAdditionalOpts from run.sh to allow proxy definition

### DIFF
--- a/4.5.6/Dockerfile
+++ b/4.5.6/Dockerfile
@@ -34,7 +34,7 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
-VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions", "$SONARQUBE_HOME/logs"]
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/

--- a/4.5.6/run.sh
+++ b/4.5.6/run.sh
@@ -10,5 +10,4 @@ exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom" \
 	"$@"

--- a/5.1.2/Dockerfile
+++ b/5.1.2/Dockerfile
@@ -34,7 +34,7 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
-VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions", "$SONARQUBE_HOME/logs"]
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/

--- a/5.1.2/run.sh
+++ b/5.1.2/run.sh
@@ -10,5 +10,4 @@ exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom" \
 	"$@"

--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -31,7 +31,7 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
-VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions", "$SONARQUBE_HOME/logs"]
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/

--- a/5.2/run.sh
+++ b/5.2/run.sh
@@ -10,5 +10,4 @@ exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom" \
 	"$@"

--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -31,7 +31,7 @@ RUN set -x \
 	&& rm sonarqube.zip* \
 	&& rm -rf $SONARQUBE_HOME/bin/*
 
-VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
+VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions", "$SONARQUBE_HOME/logs"]
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/

--- a/5.3/run.sh
+++ b/5.3/run.sh
@@ -10,5 +10,4 @@ exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="-Djava.security.egd=file:/dev/./urandom" \
 	"$@"


### PR DESCRIPTION
Hi guys,

After trying desperately for a week to correctly set the proxy definition in sonar.properties (http://stackoverflow.com/questions/35709604/sonarqube-5-3-download-plugins-behind-proxy-https/35726595?noredirect=1#comment59208893_35726595) I've found out that defining `sonar.web.javaAdditionalOpts` in `run.sh` was the culprit to problem.

It seems that when the application is starting, it'll read `sonar.properties` file but it'll not merge or even replace `sonar.web.javaAdditionalOpts` from `run.sh`, in which case I could not set the required proxies for my environment.

The property in my `sonar.properties` was set like this: `sonar.web.javaAdditionalOpts=-Djava.security.egd=file:/dev/./urandom -Dhttps.proxyHost=proxy.XXX -Dhttps.proxyPort=YYY -Dhttp.proxyHost=proxy.XXX -Dhttp.proxyPort=YYY`

I believe this is a bug as it does not allow anyone to properly use proxies in their environment.

Cheers.