### PR TITLE
changing plugin data volume to use base container

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -29,7 +29,7 @@ datadb:
   command: /bin/true
 
 plugins:
-  image: sonarqube
+  image: java:openjdk-8u45-jdk
   volumes:
    - /opt/sonarqube/extensions
    - /opt/sonarqube/lib/bundled-plugins


### PR DESCRIPTION
If we use the sonarqube image for the plugins data volume, it's going to default to use the hsql database, as well as run an actual instance of sonarqube, which we don't want in this recipe. This update ensures that we use the base jdk container instead.
