### PR TITLE
move run script COPY to allow for better volume mounting

### DIFF
--- a/5.6-alpine/Dockerfile
+++ b/5.6-alpine/Dockerfile
@@ -35,5 +35,5 @@ RUN set -x \
 VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
 
 WORKDIR $SONARQUBE_HOME
-COPY run.sh $SONARQUBE_HOME/bin/
-ENTRYPOINT ["./bin/run.sh"]
+COPY run.sh /
+ENTRYPOINT ["/run.sh"]

--- a/5.6-alpine/run.sh
+++ b/5.6-alpine/run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+cd /opt/sonarqube
+
 set -e
 
 if [ "${1:0:1}" != '-' ]; then

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -42,5 +42,5 @@ RUN set -x \
 VOLUME ["$SONARQUBE_HOME/data", "$SONARQUBE_HOME/extensions"]
 
 WORKDIR $SONARQUBE_HOME
-COPY run.sh $SONARQUBE_HOME/bin/
-ENTRYPOINT ["./bin/run.sh"]
+COPY run.sh /
+ENTRYPOINT ["/run.sh"]

--- a/5.6/run.sh
+++ b/5.6/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd /opt/sonarqube
+
 set -e
 
 if [ "${1:0:1}" != '-' ]; then


### PR DESCRIPTION
What this pull request does is simply move where the run script is COPYed into the container. I was attempting to run this container by simply mounting the volume /opt/sonarqube instead of all of the smaller suggested volumes. This is because on a kubernetes cluster it is infeasible to spin up seperate architecture for each small volume if we want persistance, thus I thought it would make more sense to simple mount one volume. 

The issue is in the order of events. A volume mount wipes anything that is already there thus:
COPY to /opt/sonarqube/bin
Volume is mounted -> /opt/sonarqube is wiped
ENTRYPOINT is attempted to be run -> run script no longer exists. 

By moving the run script outside of the /opt/sonarqube directory then it can survive a broader volume mount. 