### PR TITLE
recipies.md: Fixing the database timeout error

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -20,7 +20,7 @@ services:
     networks:
       - sonarnet
     environment:
-      - SONARQUBE_JDBC_URL=jdbc:postgresql://db:5432/sonar
+      - SONARQUBE_JDBC_URL=jdbc:postgresql://db:5432/sonar?user=sonar&password=sonar
     volumes:
       - sonarqube_conf:/opt/sonarqube/conf
       - sonarqube_data:/opt/sonarqube/data


### PR DESCRIPTION
This commit just fixes the docker-compose recipe with the username/password
in the SONARQUBE_JDBC_URL.

Error
------

The current recipe fails with the following error:

```
$ docker-compose -f sonarqube.yml logs sonarqube
Attaching to springcloudconfigpublisher_sonarqube_1
sonarqube_1 | 2016.07.23 01:42:11 INFO  app[o.s.a.AppFileSystem] Cleaning or creating temp directory /opt/sonarqube/temp
sonarqube_1 | 2016.07.23 01:42:11 INFO  app[o.s.p.m.JavaProcessLauncher] Launch process[es]: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Djava.awt.headless=true -Xmx1G -Xms256m -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -Djava.io.tmpdir=/opt/sonarqube/temp -javaagent:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management-agent.jar -cp ./lib/common/*:./lib/search/* org.sonar.search.SearchServer /opt/sonarqube/temp/sq-process7642242667881327640properties
sonarqube_1 | 2016.07.23 01:42:11 INFO   es[o.s.p.ProcessEntryPoint]  Starting es
sonarqube_1 | 2016.07.23 01:42:11 INFO   es[o.s.s.EsSettings]  Elasticsearch listening on 127.0.0.1:9001
sonarqube_1 | 2016.07.23 01:42:12 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] version[1.7.5], pid[18], build[00f95f4/2016-02-02T09:55:30Z]
sonarqube_1 | 2016.07.23 01:42:12 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] initializing ...
sonarqube_1 | 2016.07.23 01:42:12 INFO   es[o.e.plugins]  [sonar-1469238131011] loaded [], sites []
sonarqube_1 | 2016.07.23 01:42:12 INFO   es[o.elasticsearch.env]  [sonar-1469238131011] using [1] data paths, mounts [[/opt/sonarqube/data (/dev/sda1)]], net usable_space [59.9gb], net total_space [97.3gb], types [ext4]
sonarqube_1 | 2016.07.23 01:42:13 WARN   es[o.e.bootstrap]  JNA not found. native methods will be disabled.
sonarqube_1 | 2016.07.23 01:42:14 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] initialized
sonarqube_1 | 2016.07.23 01:42:14 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] starting ...
sonarqube_1 | 2016.07.23 01:42:14 INFO   es[o.e.transport]  [sonar-1469238131011] bound_address {inet[/127.0.0.1:9001]}, publish_address {inet[/127.0.0.1:9001]}
sonarqube_1 | 2016.07.23 01:42:14 INFO   es[o.e.discovery]  [sonar-1469238131011] sonarqube/9o8-Nl5rRAKaVYADWtb2Qw
sonarqube_1 | 2016.07.23 01:42:17 INFO   es[o.e.cluster.service]  [sonar-1469238131011] new_master [sonar-1469238131011][9o8-Nl5rRAKaVYADWtb2Qw][2ed2fa217689][inet[/127.0.0.1:9001]]{rack_id=sonar-1469238131011}, reason: zen-disco-join (elected_as_master)
sonarqube_1 | 2016.07.23 01:42:17 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] started
sonarqube_1 | 2016.07.23 01:42:17 INFO   es[o.e.gateway]  [sonar-1469238131011] recovered [0] indices into cluster_state
sonarqube_1 | 2016.07.23 01:42:18 INFO  app[o.s.p.m.Monitor] Process[es] is up
sonarqube_1 | 2016.07.23 01:42:18 INFO  app[o.s.p.m.JavaProcessLauncher] Launch process[web]: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djruby.management.enabled=false -Djruby.compile.invokedynamic=false -Xmx512m -Xms128m -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true -Djava.security.egd=file:/dev/./urandom -Djava.io.tmpdir=/opt/sonarqube/temp -javaagent:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management-agent.jar -cp ./lib/common/*:./lib/server/*:/opt/sonarqube/lib/jdbc/postgresql/postgresql-9.3-1102-jdbc41.jar org.sonar.server.app.WebServer /opt/sonarqube/temp/sq-process7517455854140153253properties
sonarqube_1 | 2016.07.23 01:42:19 INFO  web[o.s.p.ProcessEntryPoint] Starting web
sonarqube_1 | 2016.07.23 01:42:19 INFO  web[o.s.s.a.TomcatContexts] Webapp directory: /opt/sonarqube/web
sonarqube_1 | 2016.07.23 01:42:19 INFO  web[o.a.c.h.Http11NioProtocol] Initializing ProtocolHandler ["http-nio-0.0.0.0-9000"]
sonarqube_1 | 2016.07.23 01:42:19 INFO  web[o.a.t.u.n.NioSelectorPool] Using a shared selector for servlet write/read
sonarqube_1 | 2016.07.23 01:42:20 INFO  web[o.s.s.p.ServerImpl] SonarQube Server / 5.6 / 074f3d1169f9688d15af4aff67e7e672cbeed782
sonarqube_1 | 2016.07.23 01:42:20 INFO  web[o.sonar.db.Database] Create JDBC data source for jdbc:postgresql://db:5432/sonar
sonarqube_1 | 2016.07.23 01:43:36 ERROR web[o.a.c.c.C.[.[.[/]] Exception sending context initialized event to listener instance of class org.sonar.server.platform.PlatformServletContextListener
sonarqube_1 | java.lang.IllegalStateException: Can not connect to database. Please check connectivity and settings (see the properties prefixed by 'sonar.jdbc.').
sonarqube_1 | 	at org.sonar.db.DefaultDatabase.checkConnection(DefaultDatabase.java:104) ~[sonar-db-5.6.jar:na]
sonarqube_1 | 	at org.sonar.db.DefaultDatabase.start(DefaultDatabase.java:71) ~[sonar-db-5.6.jar:na]
sonarqube_1 | 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_91]
sonarqube_1 | 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_91]
sonarqube_1 | 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_91]
sonarqube_1 | 	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_91]
sonarqube_1 | 	at org.picocontainer.lifecycle.ReflectionLifecycleStrategy.invokeMethod(ReflectionLifecycleStrategy.java:110) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.lifecycle.ReflectionLifecycleStrategy.start(ReflectionLifecycleStrategy.java:89) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.sonar.core.platform.ComponentContainer$1.start(ComponentContainer.java:320) ~[sonar-core-5.6.jar:na]
sonarqube_1 | 	at org.picocontainer.injectors.AbstractInjectionFactory$LifecycleAdapter.start(AbstractInjectionFactory.java:84) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.behaviors.AbstractBehavior.start(AbstractBehavior.java:169) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.behaviors.Stored$RealComponentLifecycle.start(Stored.java:132) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.behaviors.Stored.start(Stored.java:110) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.DefaultPicoContainer.potentiallyStartAdapter(DefaultPicoContainer.java:1016) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.DefaultPicoContainer.startAdapters(DefaultPicoContainer.java:1009) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.picocontainer.DefaultPicoContainer.start(DefaultPicoContainer.java:767) ~[picocontainer-2.15.jar:na]
sonarqube_1 | 	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:141) ~[sonar-core-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.platform.platformlevel.PlatformLevel.start(PlatformLevel.java:84) ~[sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.platform.Platform.start(Platform.java:216) ~[sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.platform.Platform.startLevel1Container(Platform.java:175) ~[sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.platform.Platform.init(Platform.java:90) ~[sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.platform.PlatformServletContextListener.contextInitialized(PlatformServletContextListener.java:43) ~[sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4812) [tomcat-embed-core-8.0.30.jar:8.0.30]
sonarqube_1 | 	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5255) [tomcat-embed-core-8.0.30.jar:8.0.30]
sonarqube_1 | 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150) [tomcat-embed-core-8.0.30.jar:8.0.30]
sonarqube_1 | 	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1408) [tomcat-embed-core-8.0.30.jar:8.0.30]
sonarqube_1 | 	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1398) [tomcat-embed-core-8.0.30.jar:8.0.30]
sonarqube_1 | 	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_91]
sonarqube_1 | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_91]
sonarqube_1 | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_91]
sonarqube_1 | 	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_91]
sonarqube_1 | Caused by: org.apache.commons.dbcp.SQLNestedException: Cannot create PoolableConnectionFactory (Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.)
sonarqube_1 | 	at org.apache.commons.dbcp.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:1549) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	at org.apache.commons.dbcp.BasicDataSource.createDataSource(BasicDataSource.java:1388) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	at org.apache.commons.dbcp.BasicDataSource.getConnection(BasicDataSource.java:1044) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	at org.sonar.db.profiling.NullConnectionInterceptor.getConnection(NullConnectionInterceptor.java:31) ~[sonar-db-5.6.jar:na]
sonarqube_1 | 	at org.sonar.db.profiling.ProfiledDataSource.getConnection(ProfiledDataSource.java:323) ~[sonar-db-5.6.jar:na]
sonarqube_1 | 	at org.sonar.db.DefaultDatabase.checkConnection(DefaultDatabase.java:102) ~[sonar-db-5.6.jar:na]
sonarqube_1 | 	... 30 common frames omitted
sonarqube_1 | Caused by: org.postgresql.util.PSQLException: Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
sonarqube_1 | 	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:215) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:64) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.jdbc2.AbstractJdbc2Connection.<init>(AbstractJdbc2Connection.java:144) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.jdbc3.AbstractJdbc3Connection.<init>(AbstractJdbc3Connection.java:29) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.jdbc3g.AbstractJdbc3gConnection.<init>(AbstractJdbc3gConnection.java:21) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.jdbc4.AbstractJdbc4Connection.<init>(AbstractJdbc4Connection.java:31) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.jdbc4.Jdbc4Connection.<init>(Jdbc4Connection.java:24) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.Driver.makeConnection(Driver.java:410) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.Driver.connect(Driver.java:280) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.apache.commons.dbcp.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:38) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	at org.apache.commons.dbcp.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:582) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	at org.apache.commons.dbcp.BasicDataSource.validateConnectionFactory(BasicDataSource.java:1556) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	at org.apache.commons.dbcp.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:1545) ~[commons-dbcp-1.4.jar:1.4]
sonarqube_1 | 	... 35 common frames omitted
sonarqube_1 | Caused by: java.net.ConnectException: Connection refused
sonarqube_1 | 	at java.net.PlainSocketImpl.socketConnect(Native Method) ~[na:1.8.0_91]
sonarqube_1 | 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[na:1.8.0_91]
sonarqube_1 | 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[na:1.8.0_91]
sonarqube_1 | 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[na:1.8.0_91]
sonarqube_1 | 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[na:1.8.0_91]
sonarqube_1 | 	at java.net.Socket.connect(Socket.java:589) ~[na:1.8.0_91]
sonarqube_1 | 	at org.postgresql.core.PGStream.<init>(PGStream.java:61) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:109) ~[postgresql-9.3-1102-jdbc41.jar:na]
sonarqube_1 | 	... 47 common frames omitted
sonarqube_1 | 2016.07.23 01:43:36 ERROR web[o.a.c.c.StandardContext] One or more listeners failed to start. Full details will be found in the appropriate container log file
sonarqube_1 | 2016.07.23 01:43:36 ERROR web[o.a.c.c.StandardContext] Context [] startup failed due to previous errors
sonarqube_1 | 2016.07.23 01:43:36 WARN  web[o.a.c.l.WebappClassLoaderBase] The web application [ROOT] appears to have started a thread named [Timer-0] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
sonarqube_1 |  java.net.PlainSocketImpl.socketConnect(Native Method)
sonarqube_1 |  java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
sonarqube_1 |  java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
sonarqube_1 |  java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
sonarqube_1 |  java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
sonarqube_1 |  java.net.Socket.connect(Socket.java:589)
sonarqube_1 |  org.postgresql.core.PGStream.<init>(PGStream.java:61)
sonarqube_1 |  org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:109)
sonarqube_1 |  org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:64)
sonarqube_1 |  org.postgresql.jdbc2.AbstractJdbc2Connection.<init>(AbstractJdbc2Connection.java:144)
sonarqube_1 |  org.postgresql.jdbc3.AbstractJdbc3Connection.<init>(AbstractJdbc3Connection.java:29)
sonarqube_1 |  org.postgresql.jdbc3g.AbstractJdbc3gConnection.<init>(AbstractJdbc3gConnection.java:21)
sonarqube_1 |  org.postgresql.jdbc4.AbstractJdbc4Connection.<init>(AbstractJdbc4Connection.java:31)
sonarqube_1 |  org.postgresql.jdbc4.Jdbc4Connection.<init>(Jdbc4Connection.java:24)
sonarqube_1 |  org.postgresql.Driver.makeConnection(Driver.java:410)
sonarqube_1 |  org.postgresql.Driver.connect(Driver.java:280)
sonarqube_1 |  org.apache.commons.dbcp.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:38)
sonarqube_1 |  org.apache.commons.dbcp.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:582)
sonarqube_1 |  org.apache.commons.pool.impl.GenericObjectPool.addObject(GenericObjectPool.java:1617)
sonarqube_1 |  org.apache.commons.pool.impl.GenericObjectPool.ensureMinIdle(GenericObjectPool.java:1575)
sonarqube_1 |  org.apache.commons.pool.impl.GenericObjectPool.access$700(GenericObjectPool.java:190)
sonarqube_1 |  org.apache.commons.pool.impl.GenericObjectPool$Evictor.run(GenericObjectPool.java:1709)
sonarqube_1 |  java.util.TimerThread.mainLoop(Timer.java:555)
sonarqube_1 |  java.util.TimerThread.run(Timer.java:505)
sonarqube_1 | 2016.07.23 01:43:36 INFO  web[o.a.c.h.Http11NioProtocol] Starting ProtocolHandler ["http-nio-0.0.0.0-9000"]
sonarqube_1 | 2016.07.23 01:43:36 INFO  web[o.s.s.a.TomcatAccessLog] Web server is started
sonarqube_1 | 2016.07.23 01:43:36 INFO  web[o.s.s.a.EmbeddedTomcat] HTTP connector enabled on port 9000
sonarqube_1 | 2016.07.23 01:43:36 WARN  web[o.s.p.ProcessEntryPoint] Fail to start web
sonarqube_1 | java.lang.IllegalStateException: Webapp did not start
sonarqube_1 | 	at org.sonar.server.app.EmbeddedTomcat.isUp(EmbeddedTomcat.java:84) ~[sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.app.WebServer.isUp(WebServer.java:47) [sonar-server-5.6.jar:na]
sonarqube_1 | 	at org.sonar.process.ProcessEntryPoint.launch(ProcessEntryPoint.java:105) ~[sonar-process-5.6.jar:na]
sonarqube_1 | 	at org.sonar.server.app.WebServer.main(WebServer.java:68) [sonar-server-5.6.jar:na]
sonarqube_1 | 2016.07.23 01:43:36 INFO  web[o.a.c.h.Http11NioProtocol] Pausing ProtocolHandler ["http-nio-0.0.0.0-9000"]
sonarqube_1 | 2016.07.23 01:43:37 INFO  web[o.a.c.h.Http11NioProtocol] Stopping ProtocolHandler ["http-nio-0.0.0.0-9000"]
sonarqube_1 | 2016.07.23 01:43:37 INFO  web[o.a.c.h.Http11NioProtocol] Destroying ProtocolHandler ["http-nio-0.0.0.0-9000"]
sonarqube_1 | 2016.07.23 01:43:37 INFO  web[o.s.s.a.TomcatAccessLog] Web server is stopped
sonarqube_1 | 2016.07.23 01:43:37 INFO  app[o.s.p.m.Monitor] Process[es] is stopping
sonarqube_1 | 2016.07.23 01:43:38 INFO   es[o.s.p.StopWatcher]  Stopping process
sonarqube_1 | 2016.07.23 01:43:38 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] stopping ...
sonarqube_1 | 2016.07.23 01:43:38 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] stopped
sonarqube_1 | 2016.07.23 01:43:38 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] closing ...
sonarqube_1 | 2016.07.23 01:43:38 INFO   es[o.elasticsearch.node]  [sonar-1469238131011] closed
sonarqube_1 | 2016.07.23 01:43:38 INFO  app[o.s.p.m.Monitor] Process[es] is stopped
```

Fix
-----

The proposed fix solves the problem...

```
$ docker-compose -f sonarqube.yml logs   
Attaching to springcloudconfigpublisher_sonarqube_1, springcloudconfigpublisher_db_1, springcloudconfigpublisher_install_plugins_1
sonarqube_1       | 2016.07.23 01:49:16 INFO  app[o.s.a.AppFileSystem] Cleaning or creating temp directory /opt/sonarqube/temp
sonarqube_1       | 2016.07.23 01:49:16 INFO  app[o.s.p.m.JavaProcessLauncher] Launch process[es]: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Djava.awt.headless=true -Xmx1G -Xms256m -Xss256k -Djava.net.preferIPv4Stack=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -Djava.io.tmpdir=/opt/sonarqube/temp -javaagent:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management-agent.jar -cp ./lib/common/*:./lib/search/* org.sonar.search.SearchServer /opt/sonarqube/temp/sq-process8257059309651708129properties
sonarqube_1       | 2016.07.23 01:49:16 INFO   es[o.s.p.ProcessEntryPoint]  Starting es
sonarqube_1       | 2016.07.23 01:49:16 INFO   es[o.s.s.EsSettings]  Elasticsearch listening on 127.0.0.1:9001
sonarqube_1       | 2016.07.23 01:49:16 INFO   es[o.elasticsearch.node]  [sonar-1469238556042] version[1.7.5], pid[19], build[00f95f4/2016-02-02T09:55:30Z]
sonarqube_1       | 2016.07.23 01:49:16 INFO   es[o.elasticsearch.node]  [sonar-1469238556042] initializing ...
sonarqube_1       | 2016.07.23 01:49:16 INFO   es[o.e.plugins]  [sonar-1469238556042] loaded [], sites []
sonarqube_1       | 2016.07.23 01:49:16 INFO   es[o.elasticsearch.env]  [sonar-1469238556042] using [1] data paths, mounts [[/opt/sonarqube/data (/dev/sda1)]], net usable_space [59.7gb], net total_space [97.3gb], types [ext4]
sonarqube_1       | 2016.07.23 01:49:17 WARN   es[o.e.bootstrap]  JNA not found. native methods will be disabled.
sonarqube_1       | 2016.07.23 01:49:17 INFO   es[o.elasticsearch.node]  [sonar-1469238556042] initialized
sonarqube_1       | 2016.07.23 01:49:17 INFO   es[o.elasticsearch.node]  [sonar-1469238556042] starting ...
sonarqube_1       | 2016.07.23 01:49:17 INFO   es[o.e.transport]  [sonar-1469238556042] bound_address {inet[/127.0.0.1:9001]}, publish_address {inet[/127.0.0.1:9001]}
sonarqube_1       | 2016.07.23 01:49:17 INFO   es[o.e.discovery]  [sonar-1469238556042] sonarqube/DmTTfzhGRo-CPtrRnmH5Zg
sonarqube_1       | 2016.07.23 01:49:20 INFO   es[o.e.cluster.service]  [sonar-1469238556042] new_master [sonar-1469238556042][DmTTfzhGRo-CPtrRnmH5Zg][6d85dccab596][inet[/127.0.0.1:9001]]{rack_id=sonar-1469238556042}, reason: zen-disco-join (elected_as_master)
sonarqube_1       | 2016.07.23 01:49:21 INFO   es[o.elasticsearch.node]  [sonar-1469238556042] started
sonarqube_1       | 2016.07.23 01:49:21 INFO   es[o.e.gateway]  [sonar-1469238556042] recovered [0] indices into cluster_state
sonarqube_1       | 2016.07.23 01:49:21 INFO  app[o.s.p.m.Monitor] Process[es] is up
sonarqube_1       | 2016.07.23 01:49:21 INFO  app[o.s.p.m.JavaProcessLauncher] Launch process[web]: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djruby.management.enabled=false -Djruby.compile.invokedynamic=false -Xmx512m -Xms128m -XX:+HeapDumpOnOutOfMemoryError -Djava.net.preferIPv4Stack=true -Djava.security.egd=file:/dev/./urandom -Djava.io.tmpdir=/opt/sonarqube/temp -javaagent:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management-agent.jar -cp ./lib/common/*:./lib/server/*:/opt/sonarqube/lib/jdbc/postgresql/postgresql-9.3-1102-jdbc41.jar org.sonar.server.app.WebServer /opt/sonarqube/temp/sq-process6020946572332957893properties
sonarqube_1       | 2016.07.23 01:49:21 INFO  web[o.s.p.ProcessEntryPoint] Starting web
sonarqube_1       | 2016.07.23 01:49:21 INFO  web[o.s.s.a.TomcatContexts] Webapp directory: /opt/sonarqube/web
sonarqube_1       | 2016.07.23 01:49:21 INFO  web[o.a.c.h.Http11NioProtocol] Initializing ProtocolHandler ["http-nio-0.0.0.0-9000"]
sonarqube_1       | 2016.07.23 01:49:21 INFO  web[o.a.t.u.n.NioSelectorPool] Using a shared selector for servlet write/read
sonarqube_1       | 2016.07.23 01:49:22 INFO  web[o.s.s.p.ServerImpl] SonarQube Server / 5.6 / 074f3d1169f9688d15af4aff67e7e672cbeed782
sonarqube_1       | 2016.07.23 01:49:22 INFO  web[o.sonar.db.Database] Create JDBC data source for jdbc:postgresql://db:5432/sonar?user=sonar&password=sonar
sonarqube_1       | 2016.07.23 01:49:23 INFO  web[o.s.s.p.DefaultServerFileSystem] SonarQube home: /opt/sonarqube
sonarqube_1       | 2016.07.23 01:49:23 INFO  web[o.e.plugins] [sonar-1469238556042] loaded [], sites []
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin Java [java] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin JavaScript [javascript] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin Groovy [groovy] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin Dependency-Check [dependencycheck] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin Git [scmgit] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin Motion Chart [motionchart] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin CSS [css] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin C# [csharp] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin SVN [scmsvn] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin Timeline [timeline] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Plugin XML [xml] installed
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin C# / 5.0 / 17ddb09047940791828dcb70c9e225f006ab11aa
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin CSS / 1.10 / 4dbbeb4af69a9e0012d05002217f1e6800a9bb7d
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin Dependency-Check / 1.0.3 / ebffd3bb895fe8fca2dcad8ef5045549b744e13b
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin Git / 1.2 / ed0814f835a7e4b5169b6e4b6312a95dc3f71ae5
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin Groovy / 1.3.1 / 641399aaf84ae740ee415809f4f2e12d97966c0d
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin Java / 3.13.1 / cf0f0c950ba3e83a87c7fe11c6ff7e63f4864bd9
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin JavaScript / 2.11 / a9b1afa9ceef7079811779d9efc5f8026acb1400
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin Motion Chart / 1.7 / e9c4a5c95c75564b3c3b5a887b63ef50fc59a156
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin SVN / 1.3 / 73d9c8a5764e95388328bbaeb911f16fc925a448
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin Timeline / 1.5 / a9cae1328fd455a128b5d7d603381f47398c6e2a
sonarqube_1       | 2016.07.23 01:49:24 INFO  web[o.s.s.p.ServerPluginRepository] Deploy plugin XML / 1.4.1 / d2c0388961fcbe78ac597ca3fb3e262d3e733988
sonarqube_1       | 2016.07.23 01:49:25 INFO  web[o.s.d.c.PostgresCharsetHandler] Verify that database collation supports UTF8
sonarqube_1       | 2016.07.23 01:49:25 INFO  web[o.s.s.p.RailsAppsDeployer] Deploying Ruby on Rails applications
sonarqube_1       | 2016.07.23 01:49:25 INFO  web[o.s.s.p.RailsAppsDeployer] Deploying app: motionchart
sonarqube_1       | 2016.07.23 01:49:25 INFO  web[o.s.s.p.Platform] DB needs migration, entering safe mode
sonarqube_1       | 2016.07.23 01:49:25 INFO  web[jruby.rack] jruby 1.7.9 (ruby-1.8.7p370) 2013-12-06 87b108a on OpenJDK 64-Bit Server VM 1.8.0_91-8u91-b14-1~bpo8+1-b14 [linux-amd64]
sonarqube_1       | 2016.07.23 01:49:25 INFO  web[jruby.rack] using a shared (threadsafe!) runtime
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] ==  InitialSchema: migrating ==================================================
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:projects, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0060s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:snapshots, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0050s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:metrics, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0050s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:project_measures, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0200s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:rules, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0070s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:rules_parameters, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0040s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- create_table(:project_links, {})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0060s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] ==  InitialSchema: migrated (0.0570s) =========================================
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] 
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] ==  IndexDatabase: migrating ==================================================
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- index_exists?("projects", "root_id", {:name=>"projects_root_id"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0020s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- add_index("projects", "root_id", {:name=>"projects_root_id"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0030s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- index_exists?(:project_measures, [:snapshot_id, :metric_id], {:name=>"measures_sid_metric"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0020s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- add_index(:project_measures, [:snapshot_id, :metric_id], {:name=>"measures_sid_metric"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0030s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- index_exists?(:rules_parameters, :rule_id, {:name=>"rules_parameters_rule_id"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0020s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- add_index(:rules_parameters, :rule_id, {:name=>"rules_parameters_rule_id"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0020s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- index_exists?(:snapshots, :project_id, {:name=>"snapshot_project_id"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0010s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- add_index(:snapshots, :project_id, {:name=>"snapshot_project_id"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0030s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- index_exists?(:snapshots, :parent_snapshot_id, {:name=>"snapshots_parent"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0010s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- add_index(:snapshots, :parent_snapshot_id, {:name=>"snapshots_parent"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0020s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- index_exists?(:snapshots, :root_snapshot_id, {:name=>"snapshots_root"})
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration]    -> 0.0010s
sonarqube_1       | 2016.07.23 01:49:31 INFO  web[DbMigration] -- add_index(:snapshots, :root_snapshot_id, {:name=>"snapshots_root"})
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration]    -> 0.0030s
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration] -- index_exists?(:snapshots, :qualifier, {:name=>"snapshots_qualifier"})
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration]    -> 0.0010s
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration] -- add_index(:snapshots, :qualifier, {:name=>"snapshots_qualifier"})
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration]    -> 0.0030s
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration]    -> 0 rows
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration] -- index_exists?(:metrics, :name, {:name=>"metrics_unique_name"})
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration]    -> 0.0020s
sonarqube_1       | 2016.07.23 01:49:32 INFO  web[DbMigration] -- add_index(:metrics, :name, {:unique=>true, :name=>"metrics_unique_name"})
```