### PR TITLE
Add the ability to set arguments to Java when running Sonar.

### DIFF
--- a/5.6.1-alpine/run.sh
+++ b/5.6.1-alpine/run.sh
@@ -6,8 +6,7 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
-  ${SONARQUBE_JAVA_ARGS} \
+exec java ${SONARQUBE_JAVA_ARGS} -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/5.6.1-alpine/run.sh
+++ b/5.6.1-alpine/run.sh
@@ -7,6 +7,7 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  ${SONARQUBE_JAVA_ARGS} \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/5.6.1/run.sh
+++ b/5.6.1/run.sh
@@ -6,8 +6,7 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
-  ${SONARQUBE_JAVA_ARGS} \
+exec java ${SONARQUBE_JAVA_ARGS} -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/5.6.1/run.sh
+++ b/5.6.1/run.sh
@@ -7,6 +7,7 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  ${SONARQUBE_JAVA_ARGS} \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/6.0-alpine/run.sh
+++ b/6.0-alpine/run.sh
@@ -6,8 +6,7 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
-  ${SONARQUBE_JAVA_ARGS} \
+exec java ${SONARQUBE_JAVA_ARGS} -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/6.0-alpine/run.sh
+++ b/6.0-alpine/run.sh
@@ -7,6 +7,7 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  ${SONARQUBE_JAVA_ARGS} \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/6.0/run.sh
+++ b/6.0/run.sh
@@ -6,8 +6,7 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
-  ${SONARQUBE_JAVA_ARGS} \
+exec java ${SONARQUBE_JAVA_ARGS} -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/6.0/run.sh
+++ b/6.0/run.sh
@@ -7,6 +7,7 @@ if [ "${1:0:1}" != '-' ]; then
 fi
 
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  ${SONARQUBE_JAVA_ARGS} \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \


### PR DESCRIPTION
I need to be able to give sonarqube more memory so that it doesn't get an OOM trying to process our tree, but the standard recipes don't allow for that. This pull request is to add that capability.