### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/5.6.4-alpine/Dockerfile
+++ b/5.6.4-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM openjdk:8-alpine
 
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 

--- a/5.6.4/Dockerfile
+++ b/5.6.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 

--- a/6.2-alpine/Dockerfile
+++ b/6.2-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM openjdk:8-alpine
 
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 

--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 MAINTAINER David Gageot <david.gageot@sonarsource.com>
 


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).