### PR TITLE
Added variable for jvm options

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -8,7 +8,8 @@ ENV SONAR_VERSION=5.5 \
     # Defaults to using H2
     SONARQUBE_JDBC_USERNAME=sonar \
     SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=jdbc:h2:tcp://localhost:9092/sonar
+    SONARQUBE_JDBC_URL=jdbc:h2:tcp://localhost:9092/sonar \
+    SONARQUBE_JAVA_OPTS=-Xmx512m
 
 # Http port
 EXPOSE 9000

--- a/5.5/run.sh
+++ b/5.5/run.sh
@@ -6,7 +6,7 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java $SONARQUBE_JAVA_OPTS -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \


### PR DESCRIPTION
Gives the ability to better manage memory pool params (and other java opts) through the environment variables used to launch the docker instance. 512M was set as a reasonable local service size for my purposes, but possibly should be bigger, perhaps 1GiB.