### PR TITLE
Remove deprecated MAINTAINER instruction

### DIFF
--- a/5.6.6-alpine/Dockerfile
+++ b/5.6.6-alpine/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-alpine
 
-MAINTAINER David Gageot <david.gageot@sonarsource.com>
-
 ENV SONAR_VERSION=5.6.6 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration

--- a/5.6.6/Dockerfile
+++ b/5.6.6/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8
 
-MAINTAINER David Gageot <david.gageot@sonarsource.com>
-
 ENV SONAR_VERSION=5.6.6 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration

--- a/6.3.1-alpine/Dockerfile
+++ b/6.3.1-alpine/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8-alpine
 
-MAINTAINER David Gageot <david.gageot@sonarsource.com>
-
 ENV SONAR_VERSION=6.3.1 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration

--- a/6.3.1/Dockerfile
+++ b/6.3.1/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:8
 
-MAINTAINER David Gageot <david.gageot@sonarsource.com>
-
 ENV SONAR_VERSION=6.3.1 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration


### PR DESCRIPTION
maintainer is deprecated in release: v1.13.0
https://docs.docker.com/engine/deprecated/#repositoryshortid-image-references
I would like to make the change to label instead