### PR TITLE
Provide standard way to install plugins

### DIFF
--- a/6.4-alpine/run.sh
+++ b/6.4-alpine/run.sh
@@ -6,6 +6,28 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
+#Install additional plugins
+SONAR_PLUGIN_DIR="/opt/sonarqube/extensions/plugins"
+NUMBER_OF_PLUGINS=$(($((`echo $SONARQUBE_PLUGIN_LIST | sed 's/[^,]//g' | wc -c` - 1 ))+1))
+for i in $(seq 1 $NUMBER_OF_PLUGINS);
+do
+    #Extract plugin name and version
+    pluginName=$(echo "$SONARQUBE_PLUGIN_LIST" | cut -d, -f$i | cut -d: -f1)
+    pluginVersion=$(echo "$SONARQUBE_PLUGIN_LIST" | cut -d, -f$i | cut -d: -f2)
+    #Skip if desired plugin version is already installed
+    if [ -e $SONAR_PLUGIN_DIR/$pluginName-$pluginVersion.jar ]
+    then
+        echo "skipping $pluginName as it is already installed in version $pluginVersion"
+        continue
+    fi
+    #Remove any existing artifacts with wrong version
+    rm -f $SONAR_PLUGIN_DIR/$pluginName*
+    #Download desired plugin
+    echo "Installing $pluginName-$pluginVersion"
+    wget -O $SONAR_PLUGIN_DIR/$pluginName-$pluginVersion.jar --no-verbose "https://sonarsource.bintray.com/Distribution/$pluginName/$pluginName-$pluginVersion.jar"
+done
+
+#Run sonar
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \

--- a/6.4/run.sh
+++ b/6.4/run.sh
@@ -6,6 +6,28 @@ if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
 
+#Install additional plugins
+IFS=',' read -r -a plugins <<< "$SONARQUBE_PLUGIN_LIST"
+SONAR_PLUGIN_DIR="/opt/sonarqube/extensions/plugins"
+for plugin in "${plugins[@]}"
+do
+    #Extract plugin name and version
+    IFS=':' read -r -a pluginNameAndVersion <<< "$plugin"
+    pluginName=${pluginNameAndVersion[0]}
+    pluginVersion=${pluginNameAndVersion[1]}
+    #Skip if desired plugin version is already installed
+    if [ -e $SONAR_PLUGIN_DIR/$pluginName-$pluginVersion.jar ]
+    then
+        echo "skipping $pluginName as it is already installed in version $pluginVersion"
+        continue
+    fi
+    #Remove any existing artifacts with wrong version
+    rm -f $SONAR_PLUGIN_DIR/$pluginName*
+    #Download desired plugin
+    echo "Installing $pluginName-$pluginVersion"
+    curl -o $SONAR_PLUGIN_DIR/$pluginName-$pluginVersion.jar -fSL "https://sonarsource.bintray.com/Distribution/$pluginName/$pluginName-$pluginVersion.jar"
+done
+
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \

--- a/recipes.md
+++ b/recipes.md
@@ -78,5 +78,4 @@ mvn sonar:sonar \
  + Clustering
  + Upgrade
  + Admin password
- + Plugins
  + ...


### PR DESCRIPTION
My proposal for solving #93 

To install plugins from the sonarqube plugin library, you pass all desired plugins as a list in an environment variable, e.g. like so:

`docker run -e SONARQUBE_PLUGIN_LIST=sonar-github-plugin:1.4.1.822,sonar-flex-plugin:2.3 library/sonarqube`

Already installed plugins are skipped automatically and any existing version (if not the desired one) is deleted to avoid conflicts.

I will also provide a PR for updating the documentation in [docker-library/docs/sonarqube](https://github.com/docker-library/docs/tree/master/sonarqube) and reference it from here.

I am very interested in your feedback!

Regards,

Tobi