### PR TITLE
Improve layers, streamline docker cache

### DIFF
--- a/6.4-alpine/Dockerfile
+++ b/6.4-alpine/Dockerfile
@@ -1,15 +1,14 @@
 FROM openjdk:8-alpine
 
-ENV SONAR_VERSION=6.4 \
-    SONARQUBE_HOME=/opt/sonarqube \
-    # Database configuration
-    # Defaults to using H2
-    SONARQUBE_JDBC_USERNAME=sonar \
-    SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=
+ENV SONAR_VERSION=6.4
+ENV SONARQUBE_HOME=/opt/sonarqube
+# Database configuration
+# Defaults to using H2
+ENV SONARQUBE_JDBC_USERNAME=sonar
+ENV SONARQUBE_JDBC_PASSWORD=sonar
+ENV SONARQUBE_JDBC_URL=
 
-# Http port
-EXPOSE 9000
+COPY run.sh $SONARQUBE_HOME/bin/
 
 RUN set -x \
     && apk add --no-cache gnupg unzip \
@@ -33,6 +32,9 @@ RUN set -x \
 
 VOLUME "$SONARQUBE_HOME/data"
 
+# Http port
+EXPOSE 9000
+
 WORKDIR $SONARQUBE_HOME
-COPY run.sh $SONARQUBE_HOME/bin/
+
 ENTRYPOINT ["./bin/run.sh"]

--- a/6.4-alpine/Dockerfile
+++ b/6.4-alpine/Dockerfile
@@ -8,8 +8,6 @@ ENV SONARQUBE_JDBC_USERNAME=sonar
 ENV SONARQUBE_JDBC_PASSWORD=sonar
 ENV SONARQUBE_JDBC_URL=
 
-COPY run.sh $SONARQUBE_HOME/bin/
-
 RUN set -x \
     && apk add --no-cache gnupg unzip \
     && apk add --no-cache libressl wget \
@@ -29,6 +27,8 @@ RUN set -x \
     && mv sonarqube-$SONAR_VERSION sonarqube \
     && rm sonarqube.zip* \
     && rm -rf $SONARQUBE_HOME/bin/*
+
+COPY run.sh $SONARQUBE_HOME/bin/
 
 VOLUME "$SONARQUBE_HOME/data"
 


### PR DESCRIPTION
While possible, multi-line ENV is not necessary or recommended by Docker, and preserving each ENV variable allows docker to check each layer containing and ENV for changes, instead of treating any change of ENVs as a layer change. Copy 'run.sh' at a lower layer to enhance Docker cache as it is faster to execute than 'RUN apt-get' and establishes a common layer, lower.