### PR TITLE
Need depends_on

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -14,6 +14,8 @@ version: "2"
 
 services:
   sonarqube:
+    depends_on:
+      - db
     image: sonarqube
     ports:
       - "9000:9000"


### PR DESCRIPTION
If this docker-compose.yml doesn't have "depends_on", sonarqube container will down.