### PR TITLE
Manage sonarqube data volumes at the highest level

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -22,10 +22,7 @@ services:
     environment:
       - SONARQUBE_JDBC_URL=jdbc:postgresql://db:5432/sonar
     volumes:
-      - sonarqube_conf:/opt/sonarqube/conf
-      - sonarqube_data:/opt/sonarqube/data
-      - sonarqube_extensions:/opt/sonarqube/extensions
-      - sonarqube_bundled-plugins:/opt/sonarqube/lib/bundled-plugins
+      - /mnt/docker/sonarqube:/opt/sonarqube
 
   db:
     image: postgres


### PR DESCRIPTION
It is best practice to manage the docker volumes at the highest level for container data. It makes it much easier to manage as well as ensure scalability for the future when additional directories are added.