### PR TITLE
Added sonar.web.context option

### DIFF
--- a/7.0/run.sh
+++ b/7.0/run.sh
@@ -9,6 +9,7 @@ fi
 chown -R sonarqube:sonarqube $SONARQUBE_HOME
 exec gosu sonarqube \
   java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  -Dsonar.web.context="$SONARQUBE_WEB_CONTEXT" \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \


### PR DESCRIPTION
Uses the env variable  SONARQUBE_WEB_CONTEXT to set the  context path.