### PR TITLE
Sonarqube in windows containers

### DIFF
--- a/5.6.7-nanoserver/Dockerfile
+++ b/5.6.7-nanoserver/Dockerfile
@@ -1,0 +1,33 @@
+FROM openjdk:nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV SONARQUBE_VERSION=5.6.7 \
+    SONARQUBE_HOME=C:\\sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+RUN powershell -command \
+    New-Item -ItemType Directory -Force -Path $Env:SONARQUBE_HOME ; \
+    $parent_dir = Split-Path -Path $Env:SONARQUBE_HOME -Parent ; \
+    Set-Location -Path $parent_dir ; \
+    Invoke-WebRequest "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$Env:SONARQUBE_VERSION.zip" -OutFile "$Env:TEMP\sonarqube.zip"; \
+    Expand-Archive -Path "$Env:TEMP\sonarqube.zip" -DestinationPath $parent_dir ; \
+    Remove-Item "$Env:TEMP\sonarqube.zip" ; \
+    Remove-Item $Env:SONARQUBE_HOME ; \
+    $target_folder_name = Split-Path $Env:SONARQUBE_HOME -Leaf ; \
+    Rename-Item sonarqube-$Env:SONARQUBE_VERSION $target_folder_name ; \
+    Remove-Item $Env:SONARQUBE_HOME\data\*.*
+
+VOLUME $SONARQUBE_HOME\\data
+
+EXPOSE 9000
+
+WORKDIR $SONARQUBE_HOME
+
+COPY sonarqube.cmd $SONARQUBE_HOME\\bin
+
+ENTRYPOINT [".\\bin\\sonarqube.cmd"]

--- a/5.6.7-nanoserver/sonarqube.cmd
+++ b/5.6.7-nanoserver/sonarqube.cmd
@@ -1,0 +1,4 @@
+@Echo off
+Setlocal
+
+java -jar lib/sonar-application-%SONARQUBE_VERSION%.jar -Dsonar.log.console=true -Dsonar.jdbc.username="%SONARQUBE_JDBC_USERNAME%" -Dsonar.jdbc.password="%SONARQUBE_JDBC_PASSWORD%" -Dsonar.jdbc.url="%SONARQUBE_JDBC_URL%" -Dsonar.web.javaAdditionalOpts="%SONARQUBE_WEB_JVM_OPTS% -Djava.security.egd=file:/dev/./urandom"

--- a/5.6.7-windowsservercore/Dockerfile
+++ b/5.6.7-windowsservercore/Dockerfile
@@ -1,0 +1,34 @@
+FROM openjdk:windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV SONARQUBE_VERSION=5.6.7 \
+    SONARQUBE_HOME=C:\\sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+RUN powershell -command \
+    New-Item -ItemType Directory -Force -Path $Env:SONARQUBE_HOME ; \
+    $parent_dir = Split-Path -Path $Env:SONARQUBE_HOME -Parent ; \
+    Set-Location -Path $parent_dir ; \
+    [Net.ServicePointManager]::SecurityProtocol = 'Ssl3', 'Tls', 'Tls11', 'Tls12'; \
+    Invoke-WebRequest "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$Env:SONARQUBE_VERSION.zip" -OutFile "$Env:TEMP\sonarqube.zip"; \
+    Expand-Archive -Path "$Env:TEMP\sonarqube.zip" -DestinationPath $parent_dir ; \
+    Remove-Item "$Env:TEMP\sonarqube.zip" ; \
+    Remove-Item $Env:SONARQUBE_HOME ; \
+    $target_folder_name = Split-Path $Env:SONARQUBE_HOME -Leaf ; \
+    Rename-Item sonarqube-$Env:SONARQUBE_VERSION $target_folder_name ; \
+    Remove-Item $Env:SONARQUBE_HOME\data\*.*
+
+VOLUME $SONARQUBE_HOME\\data
+
+EXPOSE 9000
+
+WORKDIR $SONARQUBE_HOME
+
+COPY sonarqube.cmd $SONARQUBE_HOME\\bin
+
+ENTRYPOINT [".\\bin\\sonarqube.cmd"]

--- a/5.6.7-windowsservercore/sonarqube.cmd
+++ b/5.6.7-windowsservercore/sonarqube.cmd
@@ -1,0 +1,4 @@
+@Echo off
+Setlocal
+
+java -jar lib/sonar-application-%SONARQUBE_VERSION%.jar -Dsonar.log.console=true -Dsonar.jdbc.username="%SONARQUBE_JDBC_USERNAME%" -Dsonar.jdbc.password="%SONARQUBE_JDBC_PASSWORD%" -Dsonar.jdbc.url="%SONARQUBE_JDBC_URL%" -Dsonar.web.javaAdditionalOpts="%SONARQUBE_WEB_JVM_OPTS% -Djava.security.egd=file:/dev/./urandom"

--- a/6.7.5-nanoserver/Dockerfile
+++ b/6.7.5-nanoserver/Dockerfile
@@ -1,0 +1,33 @@
+FROM openjdk:nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV SONARQUBE_VERSION=6.7.5 \
+    SONARQUBE_HOME=C:\\sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+RUN powershell -command \
+    New-Item -ItemType Directory -Force -Path $Env:SONARQUBE_HOME ; \
+    $parent_dir = Split-Path -Path $Env:SONARQUBE_HOME -Parent ; \
+    Set-Location -Path $parent_dir ; \
+    Invoke-WebRequest "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$Env:SONARQUBE_VERSION.zip" -OutFile "$Env:TEMP\sonarqube.zip"; \
+    Expand-Archive -Path "$Env:TEMP\sonarqube.zip" -DestinationPath $parent_dir ; \
+    Remove-Item "$Env:TEMP\sonarqube.zip" ; \
+    Remove-Item $Env:SONARQUBE_HOME ; \
+    $target_folder_name = Split-Path $Env:SONARQUBE_HOME -Leaf ; \
+    Rename-Item sonarqube-$Env:SONARQUBE_VERSION $target_folder_name ; \
+    Remove-Item $Env:SONARQUBE_HOME\data\*.*
+
+VOLUME $SONARQUBE_HOME\\data
+
+EXPOSE 9000
+
+WORKDIR $SONARQUBE_HOME
+
+COPY sonarqube.cmd $SONARQUBE_HOME\\bin
+
+ENTRYPOINT [".\\bin\\sonarqube.cmd"]

--- a/6.7.5-nanoserver/sonarqube.cmd
+++ b/6.7.5-nanoserver/sonarqube.cmd
@@ -1,0 +1,4 @@
+@Echo off
+Setlocal
+
+java -jar lib/sonar-application-%SONARQUBE_VERSION%.jar -Dsonar.log.console=true -Dsonar.jdbc.username="%SONARQUBE_JDBC_USERNAME%" -Dsonar.jdbc.password="%SONARQUBE_JDBC_PASSWORD%" -Dsonar.jdbc.url="%SONARQUBE_JDBC_URL%" -Dsonar.web.javaAdditionalOpts="%SONARQUBE_WEB_JVM_OPTS% -Djava.security.egd=file:/dev/./urandom"

--- a/6.7.5-windowsservercore/Dockerfile
+++ b/6.7.5-windowsservercore/Dockerfile
@@ -1,0 +1,34 @@
+FROM openjdk:windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV SONARQUBE_VERSION=6.7.5 \
+    SONARQUBE_HOME=C:\\sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+RUN powershell -command \
+    New-Item -ItemType Directory -Force -Path $Env:SONARQUBE_HOME ; \
+    $parent_dir = Split-Path -Path $Env:SONARQUBE_HOME -Parent ; \
+    Set-Location -Path $parent_dir ; \
+    [Net.ServicePointManager]::SecurityProtocol = 'Ssl3', 'Tls', 'Tls11', 'Tls12'; \
+    Invoke-WebRequest "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$Env:SONARQUBE_VERSION.zip" -OutFile "$Env:TEMP\sonarqube.zip"; \
+    Expand-Archive -Path "$Env:TEMP\sonarqube.zip" -DestinationPath $parent_dir ; \
+    Remove-Item "$Env:TEMP\sonarqube.zip" ; \
+    Remove-Item $Env:SONARQUBE_HOME ; \
+    $target_folder_name = Split-Path $Env:SONARQUBE_HOME -Leaf ; \
+    Rename-Item sonarqube-$Env:SONARQUBE_VERSION $target_folder_name ; \
+    Remove-Item $Env:SONARQUBE_HOME\data\*.*
+
+VOLUME $SONARQUBE_HOME\\data
+
+EXPOSE 9000
+
+WORKDIR $SONARQUBE_HOME
+
+COPY sonarqube.cmd $SONARQUBE_HOME\\bin
+
+ENTRYPOINT [".\\bin\\sonarqube.cmd"]

--- a/6.7.5-windowsservercore/sonarqube.cmd
+++ b/6.7.5-windowsservercore/sonarqube.cmd
@@ -1,0 +1,4 @@
+@Echo off
+Setlocal
+
+java -jar lib/sonar-application-%SONARQUBE_VERSION%.jar -Dsonar.log.console=true -Dsonar.jdbc.username="%SONARQUBE_JDBC_USERNAME%" -Dsonar.jdbc.password="%SONARQUBE_JDBC_PASSWORD%" -Dsonar.jdbc.url="%SONARQUBE_JDBC_URL%" -Dsonar.web.javaAdditionalOpts="%SONARQUBE_WEB_JVM_OPTS% -Djava.security.egd=file:/dev/./urandom"

--- a/7.1-nanoserver/Dockerfile
+++ b/7.1-nanoserver/Dockerfile
@@ -1,0 +1,33 @@
+FROM openjdk:nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV SONARQUBE_VERSION=7.1 \
+    SONARQUBE_HOME=C:\\sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+RUN powershell -command \
+    New-Item -ItemType Directory -Force -Path $Env:SONARQUBE_HOME ; \
+    $parent_dir = Split-Path -Path $Env:SONARQUBE_HOME -Parent ; \
+    Set-Location -Path $parent_dir ; \
+    Invoke-WebRequest "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$Env:SONARQUBE_VERSION.zip" -OutFile "$Env:TEMP\sonarqube.zip"; \
+    Expand-Archive -Path "$Env:TEMP\sonarqube.zip" -DestinationPath $parent_dir ; \
+    Remove-Item "$Env:TEMP\sonarqube.zip" ; \
+    Remove-Item $Env:SONARQUBE_HOME ; \
+    $target_folder_name = Split-Path $Env:SONARQUBE_HOME -Leaf ; \
+    Rename-Item sonarqube-$Env:SONARQUBE_VERSION $target_folder_name ; \
+    Remove-Item $Env:SONARQUBE_HOME\data\*.*
+
+VOLUME $SONARQUBE_HOME\\data
+
+EXPOSE 9000
+
+WORKDIR $SONARQUBE_HOME
+
+COPY sonarqube.cmd $SONARQUBE_HOME\\bin
+
+ENTRYPOINT [".\\bin\\sonarqube.cmd"]

--- a/7.1-nanoserver/sonarqube.cmd
+++ b/7.1-nanoserver/sonarqube.cmd
@@ -1,0 +1,4 @@
+@Echo off
+Setlocal
+
+java -jar lib/sonar-application-%SONARQUBE_VERSION%.jar -Dsonar.log.console=true -Dsonar.jdbc.username="%SONARQUBE_JDBC_USERNAME%" -Dsonar.jdbc.password="%SONARQUBE_JDBC_PASSWORD%" -Dsonar.jdbc.url="%SONARQUBE_JDBC_URL%" -Dsonar.web.javaAdditionalOpts="%SONARQUBE_WEB_JVM_OPTS% -Djava.security.egd=file:/dev/./urandom"

--- a/7.1-windowsservercore/Dockerfile
+++ b/7.1-windowsservercore/Dockerfile
@@ -1,0 +1,34 @@
+FROM openjdk:windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV SONARQUBE_VERSION=7.1 \
+    SONARQUBE_HOME=C:\\sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+RUN powershell -command \
+    New-Item -ItemType Directory -Force -Path $Env:SONARQUBE_HOME ; \
+    $parent_dir = Split-Path -Path $Env:SONARQUBE_HOME -Parent ; \
+    Set-Location -Path $parent_dir ; \
+    [Net.ServicePointManager]::SecurityProtocol = 'Ssl3', 'Tls', 'Tls11', 'Tls12'; \
+    Invoke-WebRequest "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-$Env:SONARQUBE_VERSION.zip" -OutFile "$Env:TEMP\sonarqube.zip"; \
+    Expand-Archive -Path "$Env:TEMP\sonarqube.zip" -DestinationPath $parent_dir ; \
+    Remove-Item "$Env:TEMP\sonarqube.zip" ; \
+    Remove-Item $Env:SONARQUBE_HOME ; \
+    $target_folder_name = Split-Path $Env:SONARQUBE_HOME -Leaf ; \
+    Rename-Item sonarqube-$Env:SONARQUBE_VERSION $target_folder_name ; \
+    Remove-Item $Env:SONARQUBE_HOME\data\*.*
+
+VOLUME $SONARQUBE_HOME\\data
+
+EXPOSE 9000
+
+WORKDIR $SONARQUBE_HOME
+
+COPY sonarqube.cmd $SONARQUBE_HOME\\bin
+
+ENTRYPOINT [".\\bin\\sonarqube.cmd"]

--- a/7.1-windowsservercore/sonarqube.cmd
+++ b/7.1-windowsservercore/sonarqube.cmd
@@ -1,0 +1,4 @@
+@Echo off
+Setlocal
+
+java -jar lib/sonar-application-%SONARQUBE_VERSION%.jar -Dsonar.log.console=true -Dsonar.jdbc.username="%SONARQUBE_JDBC_USERNAME%" -Dsonar.jdbc.password="%SONARQUBE_JDBC_PASSWORD%" -Dsonar.jdbc.url="%SONARQUBE_JDBC_URL%" -Dsonar.web.javaAdditionalOpts="%SONARQUBE_WEB_JVM_OPTS% -Djava.security.egd=file:/dev/./urandom"


### PR DESCRIPTION
Hello,

A year ago I created windows container with SonarQube and MySQL in one container for the useful running of Sonar in windows cloud: [GitHub](https://github.com/EndurantDevs/sonarqube-mysql-windows-docker) + [DockerHub](https://hub.docker.com/r/dnikolayev/sonarqube-mysql-windows/).

Unfortunately, the official windows container of Sonarqube didn't appear still. However, there were few requests in issues about this, like  #91 

To solve this issue, I propose this pull request with windows containers of Sonarqube for all available versions. Probably, this might be a good addon on MS conference where SonarQube will be presented soon (source: Twitter)? ;)

Test builds are available at [Appveyor](https://ci.appveyor.com/project/dnikolayev/docker-sonarqube-ibn26/build/1.0.5), sorry Travis doesn't support windows still. During testing, images were pushed to [DockerHub](https://hub.docker.com/r/dnikolayev/docker-sonarqube/tags/).

There are three versions like Linux ones. Also, as for Linux ( + alpine as light version) there two base images: windowsservercore and nanoserver (light windows)

Here is an example update for commit to official docker repo (5.6.7 excluded like for Linux ones, params are equal for OpenJDK's nanoserver and windosservercore images):

```
Tags: 6.7.5-windows, 6.7.5-windows-lts, lts-windowsservercore
Architectures: windows-amd64
Directory: 6.7.5-windowsservercore
Constraints: windowsservercore-1709

Tags: 6.7.5-nanoserver, lts-nanoserver
Architectures: windows-amd64
Directory: 6.7.5-nanoserver
Constraints: nanoserver-sac2016

Tags: 7.1-windows, 7.1-windows-latest, latest-windowsservercore
Architectures: windows-amd64
Directory: 7.1-windowsservercore
Constraints: windowsservercore-1709

Tags: 7.1-nanoserver, latest-nanoserver
Architectures: windows-amd64
Directory: 7.1-nanoserver
Constraints: nanoserver-sac2016

```