### PR TITLE
Feat: push to dockerhub registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - cd "$v"
   - docker build -t "sonarqube-$v" .
   - docker images
+  - if [ "$TRAVIS_BRANCH" = "master" ]; docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push "sonarqube-$v"
 
 notifications:
   email: false


### PR DESCRIPTION
To automatically push on the registry <https://hub.docker.com/_/sonarqube/> the new images.

Need to add this env in travis :
- DOCKER_USERNAME
- DOCKER_PASSWORD

Which has access to the repo.