### PR TITLE
copying 7.5 from 7.4 and only changing version, Java 11 support

### DIFF
--- a/7.5-community/Dockerfile
+++ b/7.5-community/Dockerfile
@@ -1,0 +1,52 @@
+FROM openjdk:8
+
+ENV SONAR_VERSION=7.5 \
+    SONARQUBE_HOME=/opt/sonarqube \
+    # Database configuration
+    # Defaults to using H2
+    # DEPRECATED. Use -v sonar.jdbc.username=... instead
+    # Drop these in the next release, also in the run script
+    SONARQUBE_JDBC_USERNAME=sonar \
+    SONARQUBE_JDBC_PASSWORD=sonar \
+    SONARQUBE_JDBC_URL=
+
+# Http port
+EXPOSE 9000
+
+RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+
+# grab gosu for easy step-down from root
+RUN set -x \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && (gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        || gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4) \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true
+
+RUN set -x \
+    # pub   2048R/D26468DE 2015-05-25
+    #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
+    # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>
+    # sub   2048R/06855C1D 2015-05-25
+    && (gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE \
+	    || gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys F1182E81C792928921DBCAB4CFCA4A29D26468DE) \
+    && cd /opt \
+    && curl -o sonarqube.zip -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \
+    && curl -o sonarqube.zip.asc -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip.asc \
+    && gpg --batch --verify sonarqube.zip.asc sonarqube.zip \
+    && unzip sonarqube.zip \
+    && mv sonarqube-$SONAR_VERSION sonarqube \
+    && chown -R sonarqube:sonarqube sonarqube \
+    && rm sonarqube.zip* \
+    && rm -rf $SONARQUBE_HOME/bin/*
+
+VOLUME "$SONARQUBE_HOME/data"
+
+WORKDIR $SONARQUBE_HOME
+COPY run.sh $SONARQUBE_HOME/bin/
+USER sonarqube
+ENTRYPOINT ["./bin/run.sh"]

--- a/7.5-community/run.sh
+++ b/7.5-community/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "${1:0:1}" != '-' ]; then
+  exec "$@"
+fi
+
+# Parse Docker env vars to customize SonarQube
+#
+# e.g. Setting the env var sonar.jdbc.username=foo
+#
+# will cause SonarQube to be invoked with -Dsonar.jdbc.username=foo
+
+declare -a sq_opts
+
+while IFS='=' read -r envvar_key envvar_value
+do
+    if [[ "$envvar_key" =~ sonar.* ]]; then
+        sq_opts+=("-D${envvar_key}=${envvar_value}")
+    fi
+done < <(env)
+
+exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+  -Dsonar.log.console=true \
+  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
+  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
+  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
+  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+  "${sq_opts[@]}" \
+  "$@"


### PR DESCRIPTION
Since, Sonar 7.5 has Sonar Java plugin 5.9 which supports Java 11 while Sonar 7.4 doesn't (includes sonarjava till 5.6) 

I have created the image, ran run-test.sh successfully and also currently using it for my project.

Please ensure your pull request adheres to the following guidelines:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, please use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, please try to make sure the images run correctly on Linux
