### PR TITLE
Add JVM parameters on the wrapper

### DIFF
--- a/6.7.6-community/run.sh
+++ b/6.7.6-community/run.sh
@@ -21,7 +21,7 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java $WRAPPER_JVM_ARGS -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/7.4-community/run.sh
+++ b/7.4-community/run.sh
@@ -21,7 +21,7 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java $WRAPPER_JVM_ARGS -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \


### PR DESCRIPTION
While trying to set memory parameters on both container and jvms for our sonar instances we realized that the wrapper can't be limited via Xmx parameter, and thus, in some cases was using more than 700Mo rss in the container.

To mitigate this issue, the workaround was to set JAVA_TOOL_OPTIONS environment variable.

This pull request adds the WRAPPER_JVM_ARGS environment variable in the run.sh script, which adds the capability to control the wrapper jvm size
