### PR TITLE
Add custom PUID & PGID 

### DIFF
--- a/6.7.6-community/Dockerfile
+++ b/6.7.6-community/Dockerfile
@@ -1,6 +1,8 @@
 FROM openjdk:8
 
 ENV SONAR_VERSION=6.7.6 \
+    PUID=999 \
+    PGID=999 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2
@@ -13,7 +15,7 @@ ENV SONAR_VERSION=6.7.6 \
 # Http port
 EXPOSE 9000
 
-RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+RUN groupadd -g $PGID -r sonarqube && useradd -u $PUID -r -g sonarqube sonarqube
 
 # grab gosu for easy step-down from root
 RUN set -x \
@@ -48,5 +50,4 @@ VOLUME "$SONARQUBE_HOME/data"
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
-USER sonarqube
 ENTRYPOINT ["./bin/run.sh"]

--- a/6.7.6-community/run.sh
+++ b/6.7.6-community/run.sh
@@ -14,6 +14,12 @@ fi
 
 declare -a sq_opts
 
+# Update UID:GID for sonarqube user.
+usermod -u $PUID sonarqube && \
+groupmod -g $PGID sonarqube && \
+chown -R -h $PUID:$PGID $SONARQUBE_HOME && \
+usermod -g $PUID sonarqube
+
 while IFS='=' read -r envvar_key envvar_value
 do
     if [[ "$envvar_key" =~ sonar.* ]]; then
@@ -21,7 +27,8 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+# Add call to gosu to drop from root user to sonarqube user.
+gosu sonarqube java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/7.6-community/Dockerfile
+++ b/7.6-community/Dockerfile
@@ -1,6 +1,8 @@
 FROM openjdk:8
 
 ENV SONAR_VERSION=7.6 \
+    PUID=999 \
+    PGID=999 \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2
@@ -13,7 +15,7 @@ ENV SONAR_VERSION=7.6 \
 # Http port
 EXPOSE 9000
 
-RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+RUN groupadd -g $PGID -r sonarqube && useradd -u $PUID -r -g sonarqube sonarqube
 
 # grab gosu for easy step-down from root
 RUN set -x \
@@ -48,5 +50,4 @@ VOLUME "$SONARQUBE_HOME/data"
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
-USER sonarqube
 ENTRYPOINT ["./bin/run.sh"]

--- a/7.6-community/run.sh
+++ b/7.6-community/run.sh
@@ -14,6 +14,12 @@ fi
 
 declare -a sq_opts
 
+# Update UID:GID for sonarqube user.
+usermod -u $PUID sonarqube && \
+groupmod -g $PGID sonarqube && \
+chown -R -h $PUID:$PGID $SONARQUBE_HOME && \
+usermod -g $PUID sonarqube
+
 while IFS='=' read -r envvar_key envvar_value
 do
     if [[ "$envvar_key" =~ sonar.* ]]; then
@@ -21,7 +27,8 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+# Add call to gosu to drop from root user to sonarqube user.
+gosu sonarqube java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -96,7 +96,7 @@ for arg; do
 done
 
 if [[ $# = 0 ]]; then
-    images=(*-community *-community-alpine)
+    images=(*-community)
 else
     images=("$@")
 fi


### PR DESCRIPTION
Hi,

I suggest this evolution which allows you to manage UID and GID via environment variables and to correct the problem of mounted volumes by the same occasion (#240).

Usage: `docker run --name sonar --detach --publish 9000:9000 --volume <mount-data>:/opt/sonarqube/data --env PUID=996 --env PGID=995 sonarqube`

No problem in volume mounted or data volume according to my tests. The process also runs with the user `sonarqube`.

If some people can test on their own (Kubernetes, etc.).

Thank you.

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, please use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, please try to make sure the images run correctly on Linux
