### PR TITLE
Add healthcheck on Dockerfile

### DIFF
--- a/6.7.6-community/Dockerfile
+++ b/6.7.6-community/Dockerfile
@@ -50,3 +50,4 @@ WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
 USER sonarqube
 ENTRYPOINT ["./bin/run.sh"]
+HEALTHCHECK --start-period=30s --interval=2m --timeout=3s --retries=3 CMD curl -f http://localhost:9000/ || exit 1

--- a/7.6-community/Dockerfile
+++ b/7.6-community/Dockerfile
@@ -50,3 +50,4 @@ WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
 USER sonarqube
 ENTRYPOINT ["./bin/run.sh"]
+HEALTHCHECK --start-period=30s --interval=2m --timeout=3s --retries=3 CMD curl -f http://localhost:9000/ || exit 1


### PR DESCRIPTION
Hi,

Quick improvement, add HEALTHCHECK on Dockerfile to monitor the presence of the service.

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, please use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, please try to make sure the images run correctly on Linux
