### PR TITLE
Add env support for ldap properties

### DIFF
--- a/7.7-community/run.sh
+++ b/7.7-community/run.sh
@@ -16,7 +16,7 @@ declare -a sq_opts
 
 while IFS='=' read -r envvar_key envvar_value
 do
-    if [[ "$envvar_key" =~ sonar.* ]]; then
+    if [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
         sq_opts+=("-D${envvar_key}=${envvar_value}")
     fi
 done < <(env)


### PR DESCRIPTION
Since the ldap properties are not starting with sonar. the env vars will be ignored.

https://docs.sonarqube.org/latest/instance-administration/delegated-auth/#header-2
