### PR TITLE
Add env support Docker secrets

### DIFF
--- a/7/community/run.sh
+++ b/7/community/run.sh
@@ -11,14 +11,19 @@ fi
 # e.g. Setting the env var sonar.jdbc.username=foo
 #
 # will cause SonarQube to be invoked with -Dsonar.jdbc.username=foo
+#
+# Setting sonar.jdbc.password.file will fill in the value of
+# "$sonar.jdbc.password" from a file for Docker's secrets feature
 
 declare -a sq_opts
 
 while IFS='=' read -r envvar_key envvar_value
 do
-    if [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
-        sq_opts+=("-D${envvar_key}=${envvar_value}")
-    fi
+  if [[ "$envvar_key" =~ sonar.*.file ]] || [[ "$envvar_key" =~ ldap.*.file ]]; then
+    sq_opts+=("-D${envvar_key%.file}=$(<"$envvar_value")")
+  elif [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
+    sq_opts+=("-D${envvar_key}=${envvar_value}")
+  fi
 done < <(env)
 
 exec tail -F ./logs/es.log & # this tail on the elasticsearch logs is a temporary workaround, see https://github.com/docker-library/official-images/pull/6361#issuecomment-516184762


### PR DESCRIPTION
Setting sonar.jdbc.password.file will fill in the value of "$sonar.jdbc.password"
from a file for Docker's secrets feature

Please ensure your pull request adheres to the following guidelines:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, please use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, please try to make sure the images run correctly on Linux
