### PR TITLE
#322 Harden volume support

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -61,8 +61,6 @@ RUN ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/logs" "$SONARQUBE_HOME/logs" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data"
 
-VOLUME ["$SONARQUBE_PUBLIC_HOME/conf", "$SONARQUBE_PUBLIC_HOME/extensions", "$SONARQUBE_PUBLIC_HOME/logs", "$SONARQUBE_PUBLIC_HOME/data"]
-
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
 WORKDIR $SONARQUBE_HOME

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -6,7 +6,8 @@ ARG SONARQUBE_ZIP_URL=https://${SONARQUBE_ZIP_SERVER}/Distribution/sonarqube/son
 ARG SONARQUBE_ZIP_USERNAME
 ARG SONARQUBE_ZIP_PASSWORD
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sonarqube \
+    SONARQUBE_HOME=/opt/sq \
+    SONARQUBE_PUBLIC_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
     SONARQUBE_JDBC_PASSWORD=sonar \
     SONARQUBE_JDBC_URL=""
@@ -21,21 +22,48 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
+# download and unzip SQ
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \
-        then curl -o sonarqube.zip -fsSL $SONARQUBE_ZIP_URL ; \
+        then curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
         else curl -o sonarqube.zip -fsSL --netrc-file <(cat <<<"machine $SONARQUBE_ZIP_SERVER login $SONARQUBE_ZIP_USERNAME password $SONARQUBE_ZIP_PASSWORD") "$SONARQUBE_ZIP_URL" ; \
         fi \
     && unzip -q sonarqube.zip \
-    && mv sonarqube-${SONARQUBE_VERSION} sonarqube \
-    && chown -R sonarqube:sonarqube sonarqube \
-    && rm sonarqube.zip* \
-    && rm -rf $SONARQUBE_HOME/bin/*
+    && mv "sonarqube-${SONARQUBE_VERSION}" sq \
+    && rm sonarqube.zip* 
 
-VOLUME "$SONARQUBE_HOME/data"
+# empty bin directory from useless scripts
+# create copies or delete directories allowed to be mounted as volumes, original directories will be recreated below as symlinks
+RUN rm --recursive --force "$SONARQUBE_HOME/bin"/* \
+    && mv "$SONARQUBE_HOME/conf" "$SONARQUBE_HOME/conf_save" \
+    && mv "$SONARQUBE_HOME/extensions" "$SONARQUBE_HOME/extensions_save" \
+    && rm --recursive --force "$SONARQUBE_HOME/logs" \
+    && rm --recursive --force "$SONARQUBE_HOME/data"
+
+# create directories to be declared as volumes
+# copy into them to ensure they are initialized by 'docker run' when new volume is created
+# 'docker run' initialization will not work if volume is bound to the host's filesystem or when volume already exists
+# initialization is implemented in 'run.sh' for these cases
+RUN mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
+    && mkdir --parents "$SONARQUBE_PUBLIC_HOME/extensions" \
+    && mkdir --parents "$SONARQUBE_PUBLIC_HOME/logs" \
+    && mkdir --parents "$SONARQUBE_PUBLIC_HOME/data" \
+    && cp --recursive "$SONARQUBE_HOME/conf_save"/* "$SONARQUBE_PUBLIC_HOME/conf/" \
+    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/"
+
+RUN chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
+
+USER sonarqube
+# create symlinks to volume directories
+RUN ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
+    && ln -s "$SONARQUBE_PUBLIC_HOME/extensions" "$SONARQUBE_HOME/extensions" \
+    && ln -s "$SONARQUBE_PUBLIC_HOME/logs" "$SONARQUBE_HOME/logs" \
+    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data"
+
+VOLUME ["$SONARQUBE_PUBLIC_HOME/conf", "$SONARQUBE_PUBLIC_HOME/extensions", "$SONARQUBE_PUBLIC_HOME/logs", "$SONARQUBE_PUBLIC_HOME/data"]
+
+COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
 WORKDIR $SONARQUBE_HOME
-COPY run.sh $SONARQUBE_HOME/bin/
-USER sonarqube
 ENTRYPOINT ["./bin/run.sh"]

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -2,10 +2,15 @@
 
 set -e
 
+init_only=false
 SONARQUBE_HOME=/opt/sq 
 
 if [ "${1:0:1}" != '-' ]; then
   exec "$@"
+fi
+
+if [ "${1:-}" = "--init" ]; then
+  init_only=true
 fi
 
 # Parse Docker env vars to customize SonarQube
@@ -43,11 +48,13 @@ initialize_sq_sub_dir() {
 initialize_sq_sub_dir "conf"
 initialize_sq_sub_dir "extensions"
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
-  -Dsonar.log.console=true \
-  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
-  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
-  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
-  "${sq_opts[@]}" \
-  "$@"
+if [ "$init_only" = false ]; then
+  exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+    -Dsonar.log.console=true \
+    -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
+    -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
+    -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
+    -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+    "${sq_opts[@]}" \
+    "$@"
+fi

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+SONARQUBE_HOME=/opt/sq 
+
 if [ "${1:0:1}" != '-' ]; then
   exec "$@"
 fi
@@ -20,6 +22,26 @@ do
         sq_opts+=("-D${envvar_key}=${envvar_value}")
     fi
 done < <(env)
+
+is_empty_dir() {
+  [ -z "$(ls -A "$1")" ]
+}
+
+initialize_sq_sub_dir() {
+  local sub_dir="$1"
+
+  if is_empty_dir "$SONARQUBE_HOME/${sub_dir}"; then
+    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "$SONARQUBE_HOME/${sub_dir}/" \
+      && echo "Initialized content of $SONARQUBE_HOME/${sub_dir}" \
+      || echo "Failed to initialize content of $SONARQUBE_HOME/${sub_dir}"
+  fi
+}
+
+# Initialize conf and extensions dir in case they have been bound to a Docker Daemon host's filesystem directory
+# or to an empty volumne which has been created prior to the 'docker run' command call
+# Initialization only occurs if directory is totally empty
+initialize_sq_sub_dir "conf"
+initialize_sq_sub_dir "extensions"
 
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \


### PR DESCRIPTION
**importante notice**
This PR only contains changes to the community edition Docker image. Changes will be exactly the same on Developer and Community edition images. To ease review and make it easier to apply  feedback, I only changed one image.

1. make sure volumes mounted to `conf` and `extensions` directories have content on initiale `docker run` call
    - for Docker volumes created by the `docker run` call: initialization is handled by docker
    - for existing empty volumes or empty bound host FileSystem directory: initialization is handled by entry point script (see `run.sh`)
    - no initialization is performed by `run.sh` if mounted directory is not totally empty
2. remove declaration of volume from DockerFile because it didn't enforce anything related to usage of volumes with our image but did cause creation of Docker volumes "under the hood" which is usually missed by user and fill up their disk space

Implementing the above, implied to change the location where the SQ archive is unpacked (now in `/opt/sq`) and use symlinks from `/opt/sq` to volume mounted directories in `/opt/sonarqube`. This is transparent to the end user as all publicly advertised directories are unchanged and behavior is the same as before