### PR TITLE
fix sonar.properties properties ignored

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -18,6 +18,8 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
+RUN sed -i -e "s/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/g" \
+  $JAVA_HOME/conf/security/java.security
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -6,10 +6,7 @@ ARG SONARQUBE_ZIP_URL=https://${SONARQUBE_ZIP_SERVER}/Distribution/sonarqube/son
 ARG SONARQUBE_ZIP_USERNAME
 ARG SONARQUBE_ZIP_PASSWORD
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sonarqube \
-    SONARQUBE_JDBC_USERNAME=sonar \
-    SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=""
+    SONARQUBE_HOME=/opt/sonarqube
 
 RUN apt-get update \
     && apt-get install -y curl unzip \

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -18,8 +18,8 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
-RUN sed -i -e "s/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/g" \
-  $JAVA_HOME/conf/security/java.security
+RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
+  "$JAVA_HOME/conf/security/java.security"
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -30,10 +30,9 @@ done < <(env)
 add_env_var_as_env_prop "${SONARQUBE_JDBC_USERNAME:-}" "sonar.jdbc.username"
 add_env_var_as_env_prop "${SONARQUBE_JDBC_PASSWORD:-}" "sonar.jdbc.password"
 add_env_var_as_env_prop "${SONARQUBE_JDBC_URL:-}" "sonar.jdbc.url"
-
+add_env_var_as_env_prop "${SONARQUBE_WEB_JVM_OPTS:-}" "sonar.web.javaAdditionalOpts"
 
 exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
-  -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS:-} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -15,9 +15,9 @@ fi
 
 declare -a sq_opts
 
-add_env_var_as_env_prop() {
-  if [ "$1" ]; then
-    sq_opts+=("-D$2=$1")
+set_prop_from_env_var() {
+  if [ "$2" ]; then
+    sq_opts+=("-D$1=$2")
   fi
 }
 
@@ -34,10 +34,10 @@ do
     fi
 done < <(env)
 # map legacy env variables
-add_env_var_as_env_prop "${SONARQUBE_JDBC_USERNAME:-}" "sonar.jdbc.username"
-add_env_var_as_env_prop "${SONARQUBE_JDBC_PASSWORD:-}" "sonar.jdbc.password"
-add_env_var_as_env_prop "${SONARQUBE_JDBC_URL:-}" "sonar.jdbc.url"
-add_env_var_as_env_prop "${SONARQUBE_WEB_JVM_OPTS:-}" "sonar.web.javaAdditionalOpts"
+set_prop_from_env_var "sonar.jdbc.username" "${SONARQUBE_JDBC_USERNAME:-}"
+set_prop_from_env_var "sonar.jdbc.password" "${SONARQUBE_JDBC_PASSWORD:-}"
+set_prop_from_env_var "sonar.jdbc.url" "${SONARQUBE_JDBC_URL:-}"
+set_prop_from_env_var "sonar.web.javaAdditionalOpts" "${SONARQUBE_WEB_JVM_OPTS:-}"
 
 is_empty_dir() {
   [ -z "$(ls -A "$1")" ]

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+set -euo pipefail
 
 if [[ "${1:-}" != -* ]]; then
   exec "$@" 
@@ -9,7 +9,7 @@ fi
 declare -a sq_opts
 
 add_env_var_as_env_prop() {
-  if [ ! -z "$1" ]; then
+  if [ "$1" ]; then
     sq_opts+=("-D$2=$1")
   fi
 }
@@ -36,3 +36,4 @@ exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
   "${sq_opts[@]}" \
   "$@"
+

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
-if [ "${1:0:1}" != '-' ]; then
+if [[ "${1:-}" != -* ]]; then
   exec "$@"
 fi
 
@@ -11,9 +11,7 @@ fi
 # e.g. Setting the env var sonar.jdbc.username=foo
 #
 # will cause SonarQube to be invoked with -Dsonar.jdbc.username=foo
-
 declare -a sq_opts
-
 while IFS='=' read -r envvar_key envvar_value
 do
     if [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
@@ -21,11 +19,11 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
-  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
-  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
-  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+  -Dsonar.jdbc.username="${SONARQUBE_JDBC_USERNAME:-}" \
+  -Dsonar.jdbc.password="${SONARQUBE_JDBC_PASSWORD:-}" \
+  -Dsonar.jdbc.url="${SONARQUBE_JDBC_URL:-}" \
+  -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS:-} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -18,6 +18,8 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
+RUN sed -i -e "s/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/g" \
+  $JAVA_HOME/conf/security/java.security
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -18,8 +18,8 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
-RUN sed -i -e "s/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/g" \
-  $JAVA_HOME/conf/security/java.security
+RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
+  "$JAVA_HOME/conf/security/java.security"
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -6,10 +6,7 @@ ARG SONARQUBE_ZIP_URL=https://${SONARQUBE_ZIP_SERVER}/CommercialDistribution/son
 ARG SONARQUBE_ZIP_USERNAME
 ARG SONARQUBE_ZIP_PASSWORD
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sonarqube \
-    SONARQUBE_JDBC_USERNAME=sonar \
-    SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=""
+    SONARQUBE_HOME=/opt/sonarqube
 
 RUN apt-get update \
     && apt-get install -y curl unzip \

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -30,10 +30,9 @@ done < <(env)
 add_env_var_as_env_prop "${SONARQUBE_JDBC_USERNAME:-}" "sonar.jdbc.username"
 add_env_var_as_env_prop "${SONARQUBE_JDBC_PASSWORD:-}" "sonar.jdbc.password"
 add_env_var_as_env_prop "${SONARQUBE_JDBC_URL:-}" "sonar.jdbc.url"
-
+add_env_var_as_env_prop "${SONARQUBE_WEB_JVM_OPTS:-}" "sonar.web.javaAdditionalOpts"
 
 exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
-  -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS:-} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -15,9 +15,9 @@ fi
 
 declare -a sq_opts
 
-add_env_var_as_env_prop() {
-  if [ "$1" ]; then
-    sq_opts+=("-D$2=$1")
+set_prop_from_env_var() {
+  if [ "$2" ]; then
+    sq_opts+=("-D$1=$2")
   fi
 }
 
@@ -34,10 +34,10 @@ do
     fi
 done < <(env)
 # map legacy env variables
-add_env_var_as_env_prop "${SONARQUBE_JDBC_USERNAME:-}" "sonar.jdbc.username"
-add_env_var_as_env_prop "${SONARQUBE_JDBC_PASSWORD:-}" "sonar.jdbc.password"
-add_env_var_as_env_prop "${SONARQUBE_JDBC_URL:-}" "sonar.jdbc.url"
-add_env_var_as_env_prop "${SONARQUBE_WEB_JVM_OPTS:-}" "sonar.web.javaAdditionalOpts"
+set_prop_from_env_var "sonar.jdbc.username" "${SONARQUBE_JDBC_USERNAME:-}"
+set_prop_from_env_var "sonar.jdbc.password" "${SONARQUBE_JDBC_PASSWORD:-}"
+set_prop_from_env_var "sonar.jdbc.url" "${SONARQUBE_JDBC_URL:-}"
+set_prop_from_env_var "sonar.web.javaAdditionalOpts" "${SONARQUBE_WEB_JVM_OPTS:-}"
 
 is_empty_dir() {
   [ -z "$(ls -A "$1")" ]

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+set -euo pipefail
 
 if [[ "${1:-}" != -* ]]; then
   exec "$@" 
@@ -9,7 +9,7 @@ fi
 declare -a sq_opts
 
 add_env_var_as_env_prop() {
-  if [ ! -z "$1" ]; then
+  if [ "$1" ]; then
     sq_opts+=("-D$2=$1")
   fi
 }
@@ -36,3 +36,4 @@ exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
   "${sq_opts[@]}" \
   "$@"
+

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
-if [ "${1:0:1}" != '-' ]; then
+if [[ "${1:-}" != -* ]]; then
   exec "$@"
 fi
 
@@ -11,9 +11,7 @@ fi
 # e.g. Setting the env var sonar.jdbc.username=foo
 #
 # will cause SonarQube to be invoked with -Dsonar.jdbc.username=foo
-
 declare -a sq_opts
-
 while IFS='=' read -r envvar_key envvar_value
 do
     if [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
@@ -21,11 +19,11 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
-  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
-  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
-  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+  -Dsonar.jdbc.username="${SONARQUBE_JDBC_USERNAME:-}" \
+  -Dsonar.jdbc.password="${SONARQUBE_JDBC_PASSWORD:-}" \
+  -Dsonar.jdbc.url="${SONARQUBE_JDBC_URL:-}" \
+  -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS:-} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -18,6 +18,8 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
+RUN sed -i -e "s/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/g" \
+  $JAVA_HOME/conf/security/java.security
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -18,8 +18,8 @@ EXPOSE 9000
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 SHELL ["/bin/bash", "-c"]
-RUN sed -i -e "s/securerandom.source=file:\/dev\/random/securerandom.source=file:\/dev\/urandom/g" \
-  $JAVA_HOME/conf/security/java.security
+RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
+  "$JAVA_HOME/conf/security/java.security"
 RUN set -x \
     && cd /opt \
     && if [ "x$SONARQUBE_ZIP_USERNAME" = "x" ] ; \

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -6,10 +6,7 @@ ARG SONARQUBE_ZIP_URL=https://${SONARQUBE_ZIP_SERVER}/CommercialDistribution/son
 ARG SONARQUBE_ZIP_USERNAME
 ARG SONARQUBE_ZIP_PASSWORD
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sonarqube \
-    SONARQUBE_JDBC_USERNAME=sonar \
-    SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=""
+    SONARQUBE_HOME=/opt/sonarqube
 
 RUN apt-get update \
     && apt-get install -y curl unzip \

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -30,10 +30,9 @@ done < <(env)
 add_env_var_as_env_prop "${SONARQUBE_JDBC_USERNAME:-}" "sonar.jdbc.username"
 add_env_var_as_env_prop "${SONARQUBE_JDBC_PASSWORD:-}" "sonar.jdbc.password"
 add_env_var_as_env_prop "${SONARQUBE_JDBC_URL:-}" "sonar.jdbc.url"
-
+add_env_var_as_env_prop "${SONARQUBE_WEB_JVM_OPTS:-}" "sonar.web.javaAdditionalOpts"
 
 exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
-  -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS:-} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -15,9 +15,9 @@ fi
 
 declare -a sq_opts
 
-add_env_var_as_env_prop() {
-  if [ "$1" ]; then
-    sq_opts+=("-D$2=$1")
+set_prop_from_env_var() {
+  if [ "$2" ]; then
+    sq_opts+=("-D$1=$2")
   fi
 }
 
@@ -34,10 +34,10 @@ do
     fi
 done < <(env)
 # map legacy env variables
-add_env_var_as_env_prop "${SONARQUBE_JDBC_USERNAME:-}" "sonar.jdbc.username"
-add_env_var_as_env_prop "${SONARQUBE_JDBC_PASSWORD:-}" "sonar.jdbc.password"
-add_env_var_as_env_prop "${SONARQUBE_JDBC_URL:-}" "sonar.jdbc.url"
-add_env_var_as_env_prop "${SONARQUBE_WEB_JVM_OPTS:-}" "sonar.web.javaAdditionalOpts"
+set_prop_from_env_var "sonar.jdbc.username" "${SONARQUBE_JDBC_USERNAME:-}"
+set_prop_from_env_var "sonar.jdbc.password" "${SONARQUBE_JDBC_PASSWORD:-}"
+set_prop_from_env_var "sonar.jdbc.url" "${SONARQUBE_JDBC_URL:-}"
+set_prop_from_env_var "sonar.web.javaAdditionalOpts" "${SONARQUBE_WEB_JVM_OPTS:-}"
 
 is_empty_dir() {
   [ -z "$(ls -A "$1")" ]

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eou pipefail
+set -euo pipefail
 
 if [[ "${1:-}" != -* ]]; then
   exec "$@" 
@@ -9,7 +9,7 @@ fi
 declare -a sq_opts
 
 add_env_var_as_env_prop() {
-  if [ ! -z "$1" ]; then
+  if [ "$1" ]; then
     sq_opts+=("-D$2=$1")
   fi
 }
@@ -36,3 +36,4 @@ exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
   "${sq_opts[@]}" \
   "$@"
+

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
-if [ "${1:0:1}" != '-' ]; then
+if [[ "${1:-}" != -* ]]; then
   exec "$@"
 fi
 
@@ -11,9 +11,7 @@ fi
 # e.g. Setting the env var sonar.jdbc.username=foo
 #
 # will cause SonarQube to be invoked with -Dsonar.jdbc.username=foo
-
 declare -a sq_opts
-
 while IFS='=' read -r envvar_key envvar_value
 do
     if [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
@@ -21,11 +19,11 @@ do
     fi
 done < <(env)
 
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
-  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
-  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
-  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
-  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+  -Dsonar.jdbc.username="${SONARQUBE_JDBC_USERNAME:-}" \
+  -Dsonar.jdbc.password="${SONARQUBE_JDBC_PASSWORD:-}" \
+  -Dsonar.jdbc.url="${SONARQUBE_JDBC_URL:-}" \
+  -Dsonar.web.javaAdditionalOpts="${SONARQUBE_WEB_JVM_OPTS:-} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"


### PR DESCRIPTION
This PR fixes issue #323 

- [x] fix `sonar.jdbc` properties
- [x] fix `sonar.web.javaAdditionalOpts`
    - this property was defined to make web process use /dev/urandom instead of /dev/random by setting env property `java.security.egd`
   - there is no simple way set this property via `sonar.web.javaAdditionalOpts` and at the same time no overwrite `sonar.web.javaAdditionalOpts` defined in `sonar.properties`
   - this has been worked around by setting `securerandom.source` at Java installation level (which affects all Java processes in the container) and not at all anymore at the SQ Web process level only