### PR TITLE
improve init messages

### DIFF
--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 init_only=false
 SONARQUBE_HOME=/opt/sq
+SONARQUBE_PUBLIC_HOME=/opt/sonarqube
 
 if [[ "${1:-}" != -* ]]; then
   exec "$@"
@@ -45,11 +46,14 @@ is_empty_dir() {
 
 initialize_sq_sub_dir() {
   local sub_dir="$1"
+  local dir="$SONARQUBE_PUBLIC_HOME/${sub_dir}"
 
-  if is_empty_dir "$SONARQUBE_HOME/${sub_dir}"; then
-    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "$SONARQUBE_HOME/${sub_dir}/" \
-      && echo "Initialized content of $SONARQUBE_HOME/${sub_dir}" \
-      || echo "Failed to initialize content of $SONARQUBE_HOME/${sub_dir}"
+  if is_empty_dir "${dir}"; then
+    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "${dir}/" \
+      && echo "Initialized content of ${dir}" \
+      || echo "Failed to initialize content of ${dir}"
+  elif [ "$init_only" = true ]; then
+    echo "${dir} already has content, leaving it untouched"
   fi
 }
 

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 init_only=false
 SONARQUBE_HOME=/opt/sq
+SONARQUBE_PUBLIC_HOME=/opt/sonarqube
 
 if [[ "${1:-}" != -* ]]; then
   exec "$@"
@@ -45,11 +46,14 @@ is_empty_dir() {
 
 initialize_sq_sub_dir() {
   local sub_dir="$1"
+  local dir="$SONARQUBE_PUBLIC_HOME/${sub_dir}"
 
-  if is_empty_dir "$SONARQUBE_HOME/${sub_dir}"; then
-    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "$SONARQUBE_HOME/${sub_dir}/" \
-      && echo "Initialized content of $SONARQUBE_HOME/${sub_dir}" \
-      || echo "Failed to initialize content of $SONARQUBE_HOME/${sub_dir}"
+  if is_empty_dir "${dir}"; then
+    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "${dir}/" \
+      && echo "Initialized content of ${dir}" \
+      || echo "Failed to initialize content of ${dir}"
+  elif [ "$init_only" = true ]; then
+    echo "${dir} already has content, leaving it untouched"
   fi
 }
 

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 init_only=false
 SONARQUBE_HOME=/opt/sq
+SONARQUBE_PUBLIC_HOME=/opt/sonarqube
 
 if [[ "${1:-}" != -* ]]; then
   exec "$@"
@@ -45,11 +46,14 @@ is_empty_dir() {
 
 initialize_sq_sub_dir() {
   local sub_dir="$1"
+  local dir="$SONARQUBE_PUBLIC_HOME/${sub_dir}"
 
-  if is_empty_dir "$SONARQUBE_HOME/${sub_dir}"; then
-    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "$SONARQUBE_HOME/${sub_dir}/" \
-      && echo "Initialized content of $SONARQUBE_HOME/${sub_dir}" \
-      || echo "Failed to initialize content of $SONARQUBE_HOME/${sub_dir}"
+  if is_empty_dir "${dir}"; then
+    cp --recursive "$SONARQUBE_HOME/${sub_dir}_save/." "${dir}/" \
+      && echo "Initialized content of ${dir}" \
+      || echo "Failed to initialize content of ${dir}"
+  elif [ "$init_only" = true ]; then
+    echo "${dir} already has content, leaving it untouched"
   fi
 }
 


### PR DESCRIPTION
1. refer to the publicly know directory in logs instead of the non public one
2. display a message when not initializing the content of directories when "--init" option is used in docker run command
