### PR TITLE
apply docker hub feedback

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -1,13 +1,5 @@
 FROM openjdk:11-jre-slim
 
-ARG SONARQUBE_VERSION=8.0
-ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip
-ARG SONARQUBE_ZIP_DIR=/tmp/zip
-ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
-ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sq \
-    SONARQUBE_PUBLIC_HOME=/opt/sonarqube
-
 RUN apt-get update \
     && apt-get install -y curl unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -16,6 +8,14 @@ RUN apt-get update \
 EXPOSE 9000
 
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+
+ARG SONARQUBE_VERSION=8.0
+ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip
+ARG SONARQUBE_ZIP_DIR=/tmp/zip
+ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
+ENV SONAR_VERSION=${SONARQUBE_VERSION} \
+    SONARQUBE_HOME=/opt/sq \
+    SONARQUBE_PUBLIC_HOME=/opt/sonarqube
 
 COPY zip/* "$SONARQUBE_ZIP_DIR"/
 

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -22,9 +22,10 @@ COPY zip/* "$SONARQUBE_ZIP_DIR"/
 SHELL ["/bin/bash", "-c"]
 RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
   "$JAVA_HOME/conf/security/java.security"
-# download and unzip SQ
+
 RUN set -x \
     && cd /opt \
+# download and unzip SQ
     && if [ -f "$SONARQUBE_ZIP_LOCATION" ] ; \
         then cp "$SONARQUBE_ZIP_LOCATION" sonarqube.zip; \
         else curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
@@ -32,37 +33,33 @@ RUN set -x \
     && rm -Rf "${SONARQUBE_ZIP_DIR}" \
     && unzip -q sonarqube.zip \
     && mv "sonarqube-${SONARQUBE_VERSION}" sq \
-    && rm sonarqube.zip*
-
+    && rm sonarqube.zip* \
 # empty bin directory from useless scripts
 # create copies or delete directories allowed to be mounted as volumes, original directories will be recreated below as symlinks
-RUN rm --recursive --force "$SONARQUBE_HOME/bin"/* \
+    && rm --recursive --force "$SONARQUBE_HOME/bin"/* \
     && mv "$SONARQUBE_HOME/conf" "$SONARQUBE_HOME/conf_save" \
     && mv "$SONARQUBE_HOME/extensions" "$SONARQUBE_HOME/extensions_save" \
     && rm --recursive --force "$SONARQUBE_HOME/logs" \
-    && rm --recursive --force "$SONARQUBE_HOME/data"
-
+    && rm --recursive --force "$SONARQUBE_HOME/data" \
 # create directories to be declared as volumes
 # copy into them to ensure they are initialized by 'docker run' when new volume is created
 # 'docker run' initialization will not work if volume is bound to the host's filesystem or when volume already exists
 # initialization is implemented in 'run.sh' for these cases
-RUN mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
+    && mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/extensions" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/logs" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/data" \
     && cp --recursive "$SONARQUBE_HOME/conf_save"/* "$SONARQUBE_PUBLIC_HOME/conf/" \
-    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/"
-
-RUN chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
-
-USER sonarqube
+    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/" \
 # create symlinks to volume directories
-RUN ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
+    && ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/extensions" "$SONARQUBE_HOME/extensions" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/logs" "$SONARQUBE_HOME/logs" \
-    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data"
+    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data" \
+    && chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
 
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
+USER sonarqube
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["./bin/run.sh"]

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -1,13 +1,5 @@
 FROM openjdk:11-jre-slim
 
-ARG SONARQUBE_VERSION=8.0
-ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
-ARG SONARQUBE_ZIP_DIR=/tmp/zip
-ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
-ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sq \
-    SONARQUBE_PUBLIC_HOME=/opt/sonarqube
-
 RUN apt-get update \
     && apt-get install -y curl unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -16,6 +8,14 @@ RUN apt-get update \
 EXPOSE 9000
 
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+
+ARG SONARQUBE_VERSION=8.0
+ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
+ARG SONARQUBE_ZIP_DIR=/tmp/zip
+ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
+ENV SONAR_VERSION=${SONARQUBE_VERSION} \
+    SONARQUBE_HOME=/opt/sq \
+    SONARQUBE_PUBLIC_HOME=/opt/sonarqube
 
 COPY zip/* "$SONARQUBE_ZIP_DIR"/
 

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -22,9 +22,10 @@ COPY zip/* "$SONARQUBE_ZIP_DIR"/
 SHELL ["/bin/bash", "-c"]
 RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
   "$JAVA_HOME/conf/security/java.security"
-# download and unzip SQ
+
 RUN set -x \
     && cd /opt \
+# download and unzip SQ
     && if [ -f "$SONARQUBE_ZIP_LOCATION" ] ; \
         then cp "$SONARQUBE_ZIP_LOCATION" sonarqube.zip; \
         else curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
@@ -32,37 +33,33 @@ RUN set -x \
     && rm -Rf "${SONARQUBE_ZIP_DIR}" \
     && unzip -q sonarqube.zip \
     && mv "sonarqube-${SONARQUBE_VERSION}" sq \
-    && rm sonarqube.zip*
-
+    && rm sonarqube.zip* \
 # empty bin directory from useless scripts
 # create copies or delete directories allowed to be mounted as volumes, original directories will be recreated below as symlinks
-RUN rm --recursive --force "$SONARQUBE_HOME/bin"/* \
+    && rm --recursive --force "$SONARQUBE_HOME/bin"/* \
     && mv "$SONARQUBE_HOME/conf" "$SONARQUBE_HOME/conf_save" \
     && mv "$SONARQUBE_HOME/extensions" "$SONARQUBE_HOME/extensions_save" \
     && rm --recursive --force "$SONARQUBE_HOME/logs" \
-    && rm --recursive --force "$SONARQUBE_HOME/data"
-
+    && rm --recursive --force "$SONARQUBE_HOME/data" \
 # create directories to be declared as volumes
 # copy into them to ensure they are initialized by 'docker run' when new volume is created
 # 'docker run' initialization will not work if volume is bound to the host's filesystem or when volume already exists
 # initialization is implemented in 'run.sh' for these cases
-RUN mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
+    && mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/extensions" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/logs" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/data" \
     && cp --recursive "$SONARQUBE_HOME/conf_save"/* "$SONARQUBE_PUBLIC_HOME/conf/" \
-    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/"
-
-RUN chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
-
-USER sonarqube
+    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/" \
 # create symlinks to volume directories
-RUN ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
+    && ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/extensions" "$SONARQUBE_HOME/extensions" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/logs" "$SONARQUBE_HOME/logs" \
-    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data"
+    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data" \
+    && chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
 
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
+USER sonarqube
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["./bin/run.sh"]

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -1,13 +1,5 @@
 FROM openjdk:11-jre-slim
 
-ARG SONARQUBE_VERSION=8.0
-ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
-ARG SONARQUBE_ZIP_DIR=/tmp/zip
-ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
-ENV SONAR_VERSION=${SONARQUBE_VERSION} \
-    SONARQUBE_HOME=/opt/sq \
-    SONARQUBE_PUBLIC_HOME=/opt/sonarqube
-
 RUN apt-get update \
     && apt-get install -y curl unzip \
     && rm -rf /var/lib/apt/lists/*
@@ -16,6 +8,14 @@ RUN apt-get update \
 EXPOSE 9000
 
 RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+
+ARG SONARQUBE_VERSION=8.0
+ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
+ARG SONARQUBE_ZIP_DIR=/tmp/zip
+ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
+ENV SONAR_VERSION=${SONARQUBE_VERSION} \
+    SONARQUBE_HOME=/opt/sq \
+    SONARQUBE_PUBLIC_HOME=/opt/sonarqube
 
 COPY zip/* "$SONARQUBE_ZIP_DIR"/
 

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -22,9 +22,10 @@ COPY zip/* "$SONARQUBE_ZIP_DIR"/
 SHELL ["/bin/bash", "-c"]
 RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
   "$JAVA_HOME/conf/security/java.security"
-# download and unzip SQ
+
 RUN set -x \
     && cd /opt \
+# download and unzip SQ
     && if [ -f "$SONARQUBE_ZIP_LOCATION" ] ; \
         then cp "$SONARQUBE_ZIP_LOCATION" sonarqube.zip; \
         else curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
@@ -32,37 +33,33 @@ RUN set -x \
     && rm -Rf "${SONARQUBE_ZIP_DIR}" \
     && unzip -q sonarqube.zip \
     && mv "sonarqube-${SONARQUBE_VERSION}" sq \
-    && rm sonarqube.zip*
-
+    && rm sonarqube.zip* \
 # empty bin directory from useless scripts
 # create copies or delete directories allowed to be mounted as volumes, original directories will be recreated below as symlinks
-RUN rm --recursive --force "$SONARQUBE_HOME/bin"/* \
+    && rm --recursive --force "$SONARQUBE_HOME/bin"/* \
     && mv "$SONARQUBE_HOME/conf" "$SONARQUBE_HOME/conf_save" \
     && mv "$SONARQUBE_HOME/extensions" "$SONARQUBE_HOME/extensions_save" \
     && rm --recursive --force "$SONARQUBE_HOME/logs" \
-    && rm --recursive --force "$SONARQUBE_HOME/data"
-
+    && rm --recursive --force "$SONARQUBE_HOME/data" \
 # create directories to be declared as volumes
 # copy into them to ensure they are initialized by 'docker run' when new volume is created
 # 'docker run' initialization will not work if volume is bound to the host's filesystem or when volume already exists
 # initialization is implemented in 'run.sh' for these cases
-RUN mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
+    && mkdir --parents "$SONARQUBE_PUBLIC_HOME/conf" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/extensions" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/logs" \
     && mkdir --parents "$SONARQUBE_PUBLIC_HOME/data" \
     && cp --recursive "$SONARQUBE_HOME/conf_save"/* "$SONARQUBE_PUBLIC_HOME/conf/" \
-    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/"
-
-RUN chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
-
-USER sonarqube
+    && cp --recursive "$SONARQUBE_HOME/extensions_save"/* "$SONARQUBE_PUBLIC_HOME/extensions/" \
 # create symlinks to volume directories
-RUN ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
+    && ln -s "$SONARQUBE_PUBLIC_HOME/conf" "$SONARQUBE_HOME/conf" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/extensions" "$SONARQUBE_HOME/extensions" \
     && ln -s "$SONARQUBE_PUBLIC_HOME/logs" "$SONARQUBE_HOME/logs" \
-    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data"
+    && ln -s "$SONARQUBE_PUBLIC_HOME/data" "$SONARQUBE_HOME/data" \
+    && chown --recursive sonarqube:sonarqube "$SONARQUBE_HOME" "$SONARQUBE_PUBLIC_HOME"
 
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
+USER sonarqube
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["./bin/run.sh"]


### PR DESCRIPTION
Using a single `RUN` command has a significant impact on the image size.

The following layers

```
e985a52a8e94        About a minute ago   |4 SONARQUBE_VERSION=8.0.0.29057 SONARQUBE_Z…   82B                 
1e9aca6a8b61        About a minute ago   /bin/bash -c #(nop)  USER sonarqube             0B                  
7aef49644565        About a minute ago   |4 SONARQUBE_VERSION=8.0.0.29057 SONARQUBE_Z…   352MB               
2e875e695a59        About a minute ago   |4 SONARQUBE_VERSION=8.0.0.29057 SONARQUBE_Z…   90.1MB              
9f3c4e0ec5ca        About a minute ago   |4 SONARQUBE_VERSION=8.0.0.29057 SONARQUBE_Z…   90.1MB              
4efa983381b8        About a minute ago   |4 SONARQUBE_VERSION=8.0.0.29057 SONARQUBE_Z…   262MB   
```

are replaced by the following single one:

```
24f350324d53        10 seconds ago      |4 SONARQUBE_VERSION=8.0.0.29057 SONARQUBE_Z…   352MB               
```