### PR TITLE
remove all dogfood related code for SQ 8 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,44 +5,19 @@ language: bash
 services:
   - docker
 
-env:
-  global:
-    - ARTIFACTORY_PRIVATE_USERNAME=private-reader
-    - SONARQUBE_BUILD_NUMBER=8.0.0.29231
-
 script:
   - 'if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
         ./run-public-image-tests.sh;
     fi'
   - docker build "7/community" --tag sonarqube:7
   - ./run-tests.sh "sonarqube:7"
-  - >-
-    SQ_VERSION="$SONARQUBE_BUILD_NUMBER"
-    ZIP_SERVER="repox.jfrog.io"
-    ZIP_URL="https://repox.jfrog.io/repox/sonarsource-builds/org/sonarsource/sonarqube/sonar-application/$SONARQUBE_BUILD_NUMBER/sonar-application-$SONARQUBE_BUILD_NUMBER.zip"
-    ZIP_USERNAME="$ARTIFACTORY_PRIVATE_USERNAME"
-    ZIP_PASSWORD="$ARTIFACTORY_PRIVATE_PASSWORD"
-    ./8/build-docker-from-private-repo.sh community
-    --tag sonarqube:8
+  - docker build 8/community --tag sonarqube:8
   - ./run-tests.sh "sonarqube:8"
-  - >-
-    SQ_VERSION="$SONARQUBE_BUILD_NUMBER"
-    ZIP_SERVER="repox.jfrog.io"
-    ZIP_URL="https://repox.jfrog.io/repox/sonarsource-builds/com/sonarsource/sonarqube/sonarqube-developer/$SONARQUBE_BUILD_NUMBER/sonarqube-developer-$SONARQUBE_BUILD_NUMBER.zip"
-    ZIP_USERNAME="$ARTIFACTORY_PRIVATE_USERNAME"
-    ZIP_PASSWORD="$ARTIFACTORY_PRIVATE_PASSWORD"
-    ./8/build-docker-from-private-repo.sh developer
-    --tag sonarqube:8-de
+  - docker build 8/developer --tag sonarqube:8-de
   - ./run-tests.sh "sonarqube:8-de"
-  - >-
-    SQ_VERSION="$SONARQUBE_BUILD_NUMBER"
-    ZIP_SERVER="repox.jfrog.io"
-    ZIP_URL="https://repox.jfrog.io/repox/sonarsource-builds/com/sonarsource/sonarqube/sonarqube-enterprise/$SONARQUBE_BUILD_NUMBER/sonarqube-enterprise-$SONARQUBE_BUILD_NUMBER.zip"
-    ZIP_USERNAME="$ARTIFACTORY_PRIVATE_USERNAME"
-    ZIP_PASSWORD="$ARTIFACTORY_PRIVATE_PASSWORD"
-    ./8/build-docker-from-private-repo.sh enterprise
-    --tag sonarqube:8-ee
+  - docker build 8/enterprise --tag sonarqube:8-ee
   - ./run-tests.sh "sonarqube:8-ee"
+
 notifications:
   email: false
   webhooks:

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -11,13 +11,9 @@ RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 ARG SONARQUBE_VERSION=8.0
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip
-ARG SONARQUBE_ZIP_DIR=/tmp/zip
-ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
     SONARQUBE_HOME=/opt/sq \
     SONARQUBE_PUBLIC_HOME=/opt/sonarqube
-
-COPY zip/* "$SONARQUBE_ZIP_DIR"/
 
 SHELL ["/bin/bash", "-c"]
 RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
@@ -26,10 +22,7 @@ RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/
 RUN set -x \
     && cd /opt \
 # download and unzip SQ
-    && if [ -f "$SONARQUBE_ZIP_LOCATION" ] ; \
-        then cp "$SONARQUBE_ZIP_LOCATION" sonarqube.zip; \
-        else curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
-        fi \
+    && curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" \
     && rm -Rf "${SONARQUBE_ZIP_DIR}" \
     && unzip -q sonarqube.zip \
     && mv "sonarqube-${SONARQUBE_VERSION}" sq \

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -11,13 +11,9 @@ RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 ARG SONARQUBE_VERSION=8.0
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
-ARG SONARQUBE_ZIP_DIR=/tmp/zip
-ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
     SONARQUBE_HOME=/opt/sq \
     SONARQUBE_PUBLIC_HOME=/opt/sonarqube
-
-COPY zip/* "$SONARQUBE_ZIP_DIR"/
 
 SHELL ["/bin/bash", "-c"]
 RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
@@ -26,10 +22,7 @@ RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/
 RUN set -x \
     && cd /opt \
 # download and unzip SQ
-    && if [ -f "$SONARQUBE_ZIP_LOCATION" ] ; \
-        then cp "$SONARQUBE_ZIP_LOCATION" sonarqube.zip; \
-        else curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
-        fi \
+    && curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" \
     && rm -Rf "${SONARQUBE_ZIP_DIR}" \
     && unzip -q sonarqube.zip \
     && mv "sonarqube-${SONARQUBE_VERSION}" sq \

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -11,13 +11,9 @@ RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
 
 ARG SONARQUBE_VERSION=8.0
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
-ARG SONARQUBE_ZIP_DIR=/tmp/zip
-ARG SONARQUBE_ZIP_LOCATION=$SONARQUBE_ZIP_DIR/sonarqube-${SONARQUBE_VERSION}.zip
 ENV SONAR_VERSION=${SONARQUBE_VERSION} \
     SONARQUBE_HOME=/opt/sq \
     SONARQUBE_PUBLIC_HOME=/opt/sonarqube
-
-COPY zip/* "$SONARQUBE_ZIP_DIR"/
 
 SHELL ["/bin/bash", "-c"]
 RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/dev/urandom?g" \
@@ -26,10 +22,7 @@ RUN sed -i -e "s?securerandom.source=file:/dev/random?securerandom.source=file:/
 RUN set -x \
     && cd /opt \
 # download and unzip SQ
-    && if [ -f "$SONARQUBE_ZIP_LOCATION" ] ; \
-        then cp "$SONARQUBE_ZIP_LOCATION" sonarqube.zip; \
-        else curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" ; \
-        fi \
+    && curl -o sonarqube.zip -fsSL "$SONARQUBE_ZIP_URL" \
     && rm -Rf "${SONARQUBE_ZIP_DIR}" \
     && unzip -q sonarqube.zip \
     && mv "sonarqube-${SONARQUBE_VERSION}" sq \


### PR DESCRIPTION
This PR makes the last changes, to be merged into `branch-8`, needed to submit a valid PR to DockerHub for publication of the Docker image for SQ 8.0:

- [X] remove dogfood related code from images
- [X] test official images instead of images built from private artifacts in ITs