### PR TITLE
Allow building image using alternative uid/gid. Best attempt at changng perms of mounted files during run

### DIFF
--- a/7/community/Dockerfile
+++ b/7/community/Dockerfile
@@ -4,16 +4,21 @@ RUN apt-get update \
     && apt-get install -y curl gnupg2 unzip \
     && rm -rf /var/lib/apt/lists/*
 
+ARG PUID=999
+ARG PGID=999
+
 ENV SONAR_VERSION=7.9.1 \
     SONARQUBE_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
     SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=""
+    SONARQUBE_JDBC_URL="" \
+    PUID=$PUID \
+    PGID=$PGID
 
 # Http port
 EXPOSE 9000
 
-RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+RUN groupadd -g $PGID -r sonarqube && useradd -u $PUID -r -g sonarqube sonarqube -d $SONARQUBE_HOME
 
 # pub   2048R/D26468DE 2015-05-25
 #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
@@ -38,9 +43,12 @@ RUN set -x \
     && rm sonarqube.zip* \
     && rm -rf $SONARQUBE_HOME/bin/*
 
-VOLUME "$SONARQUBE_HOME/data"
+VOLUME $SONARQUBE_HOME/data
+VOLUME $SONARQUBE_HOME/conf
+VOLUME $SONARQUBE_HOME/logs
+VOLUME $SONARQUBE_HOME/extensions
 
 WORKDIR $SONARQUBE_HOME
-COPY run.sh $SONARQUBE_HOME/bin/
+COPY --chown=sonarqube:sonarqube run.sh $SONARQUBE_HOME/bin/
 USER sonarqube
 ENTRYPOINT ["./bin/run.sh"]

--- a/7/community/run.sh
+++ b/7/community/run.sh
@@ -14,6 +14,8 @@ fi
 
 declare -a sq_opts
 
+chown -R -h $PUID:$PGID $SONARQUBE_HOME || true
+
 while IFS='=' read -r envvar_key envvar_value
 do
     if [[ "$envvar_key" =~ sonar.* ]] || [[ "$envvar_key" =~ ldap.* ]]; then
@@ -22,7 +24,8 @@ do
 done < <(env)
 
 exec tail -F ./logs/es.log & # this tail on the elasticsearch logs is a temporary workaround, see https://github.com/docker-library/official-images/pull/6361#issuecomment-516184762
-exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
+# Add call to gosu to drop from root user to sonarqube user.
+exec java -jar "lib/sonar-application-$SONAR_VERSION.jar" \
   -Dsonar.log.console=true \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -7,7 +7,12 @@ RUN apt-get update \
 # Http port
 EXPOSE 9000
 
-RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+ARG PUID=999
+ARG PGID=999
+ENV PUID=$PUID \
+    PGID=$PGID
+RUN groupadd -g $PGID -r sonarqube && useradd -u $PUID -r -g sonarqube sonarqube
+
 
 ARG SONARQUBE_VERSION=8.0
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip

--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -16,6 +16,8 @@ fi
 
 declare -a sq_opts
 
+chown -R -h $PUID:$PGID $SONARQUBE_HOME || true
+
 set_prop_from_env_var() {
   if [ "$2" ]; then
     sq_opts+=("-D$1=$2")

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -7,7 +7,11 @@ RUN apt-get update \
 # Http port
 EXPOSE 9000
 
-RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+ARG PUID=999
+ARG PGID=999
+ENV PUID=$PUID \
+    PGID=$PGID
+RUN groupadd -g $PGID -r sonarqube && useradd -u $PUID -r -g sonarqube sonarqube
 
 ARG SONARQUBE_VERSION=8.0
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -16,6 +16,8 @@ fi
 
 declare -a sq_opts
 
+chown -R -h $PUID:$PGID $SONARQUBE_HOME || true
+
 set_prop_from_env_var() {
   if [ "$2" ]; then
     sq_opts+=("-D$1=$2")

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -7,7 +7,11 @@ RUN apt-get update \
 # Http port
 EXPOSE 9000
 
-RUN groupadd -r sonarqube && useradd -r -g sonarqube sonarqube
+ARG PUID=999
+ARG PGID=999
+ENV PUID=$PUID \
+    PGID=$PGID
+RUN groupadd -g $PGID -r sonarqube && useradd -u $PUID -r -g sonarqube sonarqube
 
 ARG SONARQUBE_VERSION=8.0
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -16,6 +16,8 @@ fi
 
 declare -a sq_opts
 
+chown -R -h $PUID:$PGID $SONARQUBE_HOME || true
+
 set_prop_from_env_var() {
   if [ "$2" ]; then
     sq_opts+=("-D$1=$2")


### PR DESCRIPTION
This is a take on https://github.com/SonarSource/docker-sonarqube/pulls which seems to have stalled and does not seem to function as expected during testing

Please ensure your pull request adheres to the following guidelines:

- Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make

As a CentOS 7 user, the image as built creates a sonarqube user with uid/gid 999 which is already taken by the polkitd system user. This change allows downstream users to build these images with a user-provided uid/gid to not conflict with pre-existing uid/gids on their systems. 

Seems to work via runtest

```
$ ./run-tests.sh sonar
[info] sonar: container started: 17c650cccd360c54c9c7434d46631668914123c00259583299c55e650868b39a
[info] sonar: waiting for web server to start ...
[info] sonar: waiting for web server to start ...
[info] sonar: waiting for web server to start ...
[info] sonar: waiting for web server to start ...
HTTP/1.1 200
[info] sonar: waiting for sonarqube to be ready ...
[info] sonar: waiting for sonarqube to be ready ...
[info] sonar: waiting for sonarqube to be ready ...
[info] sonar: waiting for sonarqube to be ready ...
[info] sonar: waiting for sonarqube to be ready ...
{"id":"BF41A1F2-AW4YV3fL5QlKwm5moRmw","version":"7.9.1.27448","status":"UP"}
[info] sonar: OK !
[info] sonar: stopping container: 17c650cccd360c54c9c7434d46631668914123c00259583299c55e650868b39a
17c650cccd360c54c9c7434d46631668914123c00259583299c55e650868b39a

sonar => success
```