### PR TITLE
SONAR-12696 Add libfreetype6 and libfontconfig1 for svg-badges

### DIFF
--- a/7/community/Dockerfile
+++ b/7/community/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl gnupg2 unzip \
+    && apt-get install -y curl gnupg2 unzip libfreetype6 libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SONAR_VERSION=7.9.1 \

--- a/7/community/Dockerfile
+++ b/7/community/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl gnupg2 unzip libfreetype6 libfontconfig1 \
+    && apt-get install -y curl gnupg2 unzip \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SONAR_VERSION=7.9.1 \

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl unzip \
+    && apt-get install -y curl unzip libfreetype6 libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Http port

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl unzip \
+    && apt-get install -y curl unzip libfreetype6 libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Http port

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl unzip \
+    && apt-get install -y curl unzip libfreetype6 libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Http port


### PR DESCRIPTION
The docker image currently does not allow the SVG badges plugin to be installed because that requires libfreetype and fontconfig.

Currently if you install the svg plugin in the docker image it will fail to start.

Added those to the Dockerfile and tested that the SVG plugin can be installed.