### PR TITLE
Error Plugin SonarQube Badges

### DIFF
--- a/7/community/Dockerfile
+++ b/7/community/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl gnupg2 unzip \
+    && apt-get install -y curl gnupg2 libfreetype6 unzip \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SONAR_VERSION=7.9.1 \


### PR DESCRIPTION
This error ocurrs when install Badges on SonarQube, after restart. (Using Docker)
![image](https://user-images.githubusercontent.com/11349296/68608034-bf545c00-0490-11ea-8c27-be776507410f.png)
