### PR TITLE
Symlink the entrypoint script to the 7.9 location

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -53,6 +53,10 @@ RUN set -x \
 
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
+# Backwards compatibility for Helm Chart users
+RUN mkdir -p "$SONARQUBE_PUBLIC_HOME/bin" && \
+    ln -s "$SONARQUBE_HOME/bin/run.sh" "$SONARQUBE_PUBLIC_HOME/bin/run.sh" 
+
 USER sonarqube
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["./bin/run.sh"]

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -53,6 +53,10 @@ RUN set -x \
 
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
+# Backwards compatibility for Helm Chart users
+RUN mkdir -p "$SONARQUBE_PUBLIC_HOME/bin" && \
+    ln -s "$SONARQUBE_HOME/bin/run.sh" "$SONARQUBE_PUBLIC_HOME/bin/run.sh" 
+
 USER sonarqube
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["./bin/run.sh"]

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -53,6 +53,10 @@ RUN set -x \
 
 COPY --chown=sonarqube:sonarqube run.sh "$SONARQUBE_HOME/bin/"
 
+# Backwards compatibility for Helm Chart users
+RUN mkdir -p "$SONARQUBE_PUBLIC_HOME/bin" && \
+    ln -s "$SONARQUBE_HOME/bin/run.sh" "$SONARQUBE_PUBLIC_HOME/bin/run.sh" 
+
 USER sonarqube
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["./bin/run.sh"]


### PR DESCRIPTION
The stable SonarQube Helm chart directly refers to the entrypoint script defined in 7.9.1's image. Since this file moved in the new approach with 8.x, the images do not work for helm users. With the added symlink, this allows the helm charts to continue to function with the new images.

Please ensure your pull request adheres to the following guidelines:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, please use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, please try to make sure the images run correctly on Linux
