### PR TITLE
SONAR-12696 Add libfreetype6 and libfontconfig1 for svg-badges backport to 7

### DIFF
--- a/7/community/Dockerfile
+++ b/7/community/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre-slim
 
 RUN apt-get update \
-    && apt-get install -y curl gnupg2 unzip \
+    && apt-get install -y curl gnupg2 unzip libfreetype6 libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SONAR_VERSION=7.9.2 \


### PR DESCRIPTION
with SONAR-12969 the fix was only backported to 8 but not 7..

... i really need to have to have the svg-badges on the current LTS version which is not possible ATM
