### PR TITLE
Fix typos in run.sh for v8

### DIFF
--- a/8/community/run.sh
+++ b/8/community/run.sh
@@ -58,7 +58,7 @@ initialize_sq_sub_dir() {
 }
 
 # Initialize conf and extensions dir in case they have been bound to a Docker Daemon host's filesystem directory
-# or to an empty volumne which has been created prior to the 'docker run' command call
+# or to an empty volume which has been created prior to the 'docker run' command call
 # Initialization only occurs if directory is totally empty
 initialize_sq_sub_dir "conf"
 initialize_sq_sub_dir "extensions"

--- a/8/developer/run.sh
+++ b/8/developer/run.sh
@@ -58,7 +58,7 @@ initialize_sq_sub_dir() {
 }
 
 # Initialize conf and extensions dir in case they have been bound to a Docker Daemon host's filesystem directory
-# or to an empty volumne which has been created prior to the 'docker run' command call
+# or to an empty volume which has been created prior to the 'docker run' command call
 # Initialization only occurs if directory is totally empty
 initialize_sq_sub_dir "conf"
 initialize_sq_sub_dir "extensions"

--- a/8/enterprise/run.sh
+++ b/8/enterprise/run.sh
@@ -58,7 +58,7 @@ initialize_sq_sub_dir() {
 }
 
 # Initialize conf and extensions dir in case they have been bound to a Docker Daemon host's filesystem directory
-# or to an empty volumne which has been created prior to the 'docker run' command call
+# or to an empty volume which has been created prior to the 'docker run' command call
 # Initialization only occurs if directory is totally empty
 initialize_sq_sub_dir "conf"
 initialize_sq_sub_dir "extensions"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] If the PR modifies or adds images, please use the `run-tests.sh imagedir` command to verify the image works
- [ ] If the PR modifies or adds images, please try to make sure the images run correctly on Linux

Reason: typo in `run.sh` code for v8.