### PR TITLE
Dockerfile updated: Added RUN chmod +x for run.sh and sonar.sh

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -127,7 +127,6 @@ COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
-RUN chmod +x bin/run.sh
-RUN chmod +x bin/sonar.sh
+RUN chmod +x bin/run.sh bin/sonar.sh
 ENTRYPOINT ["bin/run.sh"]
 CMD ["bin/sonar.sh"]

--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -1,3 +1,4 @@
+
 FROM alpine:3.11
 ENV JAVA_VERSION="jdk-11.0.6+10" \
     LANG='en_US.UTF-8' \
@@ -126,5 +127,7 @@ COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
+RUN chmod +x bin/run.sh
+RUN chmod +x bin/sonar.sh
 ENTRYPOINT ["bin/run.sh"]
 CMD ["bin/sonar.sh"]

--- a/8/developer/Dockerfile
+++ b/8/developer/Dockerfile
@@ -126,5 +126,6 @@ COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
+RUN chmod +x bin/run.sh bin/sonar.sh
 ENTRYPOINT ["bin/run.sh"]
 CMD ["bin/sonar.sh"]

--- a/8/enterprise/Dockerfile
+++ b/8/enterprise/Dockerfile
@@ -121,10 +121,11 @@ RUN set -ex \
     # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
     && chmod -R 777 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}" \
     && apk del --purge build-dependencies
-    
+
 COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
+RUN chmod +x bin/run.sh bin/sonar.sh
 ENTRYPOINT ["bin/run.sh"]
 CMD ["bin/sonar.sh"]


### PR DESCRIPTION
If run.sh and sonar.sh in your own environment doesn't have the execution attribute, building the new image will fail with a `permission denied` error. I had created both files manualy and forgot to set the -x permission. If set the execution attribute within de Dockerfile you dont have to worry about it anymore.