### PR TITLE
Add option to disable the es bootstrap checks

### DIFF
--- a/7/community/run.sh
+++ b/7/community/run.sh
@@ -27,6 +27,7 @@ exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
   -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
   -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
+  -Dsonar.es.bootstrap.checks.disable="$SONAR_ES_BOOTSTRAP_CHECKS_DISABLE" \
   -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"


### PR DESCRIPTION
Currently sonar qube can not be hosted in azure app service as it gives vm.max_map_count error. There is already a flag to disable the bootstrap checks but azure app service replaced "." with "-" so there is no way currently to set the flag sonar.es.bootstrap.checks.disable from app service. With this changes user will be able to set the env variable value from app settting.

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [ ] If the PR modifies or adds images, try to make sure the images run correctly on Linux
