### PR TITLE
Check presence of SONARQUBE_*

### DIFF
--- a/7/community/run.sh
+++ b/7/community/run.sh
@@ -21,12 +21,22 @@ do
     fi
 done < <(env)
 
+if [ -n "$SONARQUBE_JDBC_USERNAME" ]
+then
+    sq_opts+=("-Dsonar.jdbc.username='$SONARQUBE_JDBC_USERNAME'")
+fi
+if [ -n "$SONARQUBE_JDBC_PASSWORD" ]
+then
+    sq_opts+=("-Dsonar.jdbc.password='$SONARQUBE_JDBC_PASSWORD'")
+fi
+if [ -n "$SONARQUBE_JDBC_URL" ]
+then
+    sq_opts+=("-Dsonar.jdbc.url='$SONARQUBE_JDBC_URL'")
+fi
+
 exec tail -F ./logs/es.log & # this tail on the elasticsearch logs is a temporary workaround, see https://github.com/docker-library/official-images/pull/6361#issuecomment-516184762
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
-  -Dsonar.jdbc.username="$SONARQUBE_JDBC_USERNAME" \
-  -Dsonar.jdbc.password="$SONARQUBE_JDBC_PASSWORD" \
-  -Dsonar.jdbc.url="$SONARQUBE_JDBC_URL" \
   -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"


### PR DESCRIPTION
When SONARQUBE_* are not set, previous implementation pass -D options with empty values.
Doing this, any values set in the property file are ignored.

This patch avoid setting -D options when var env are not set.

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [ ] If the PR modifies or adds images, try to make sure the images run correctly on Linux
