### PR TITLE
Support forward-compatible env vars in 7.9 LTS

### DIFF
--- a/7/community/Dockerfile
+++ b/7/community/Dockerfile
@@ -5,6 +5,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV SONAR_VERSION=7.9.6 \
+    SONAR_HOME="" \
+    SONAR_JDBC_USERNAME="" \
+    SONAR_JDBC_PASSWORD="" \
+    SONAR_JDBC_URL="" \
+    # Deprecated
     SONARQUBE_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
     SONARQUBE_JDBC_PASSWORD=sonar \

--- a/7/community/run.sh
+++ b/7/community/run.sh
@@ -14,17 +14,17 @@ fi
 
 declare -a sq_opts
 
-if [ -n "$SONARQUBE_JDBC_USERNAME" ]
+if [ -n "$SONAR_JDBC_USERNAME" ] || [ -n "$SONARQUBE_JDBC_USERNAME" ]
 then
-    sq_opts+=("-Dsonar.jdbc.username=$SONARQUBE_JDBC_USERNAME")
+    sq_opts+=("-Dsonar.jdbc.username=${SONAR_JDBC_USERNAME:-$SONARQUBE_JDBC_USERNAME}")
 fi
-if [ -n "$SONARQUBE_JDBC_PASSWORD" ]
+if [ -n "$SONAR_JDBC_PASSWORD" ] || [ -n "$SONARQUBE_JDBC_PASSWORD" ]
 then
-    sq_opts+=("-Dsonar.jdbc.password=$SONARQUBE_JDBC_PASSWORD")
+    sq_opts+=("-Dsonar.jdbc.password=${SONAR_JDBC_PASSWORD:-$SONARQUBE_JDBC_PASSWORD}")
 fi
-if [ -n "$SONARQUBE_JDBC_URL" ]
+if [ -n "$SONAR_JDBC_URL" ] || [ -n "$SONARQUBE_JDBC_URL" ]
 then
-    sq_opts+=("-Dsonar.jdbc.url=$SONARQUBE_JDBC_URL")
+    sq_opts+=("-Dsonar.jdbc.url=${SONAR_JDBC_URL:-$SONARQUBE_JDBC_URL}")
 fi
 
 while IFS='=' read -r envvar_key envvar_value
@@ -37,6 +37,6 @@ done < <(env)
 exec tail -F ./logs/es.log & # this tail on the elasticsearch logs is a temporary workaround, see https://github.com/docker-library/official-images/pull/6361#issuecomment-516184762
 exec java -jar lib/sonar-application-$SONAR_VERSION.jar \
   -Dsonar.log.console=true \
-  -Dsonar.web.javaAdditionalOpts="$SONARQUBE_WEB_JVM_OPTS -Djava.security.egd=file:/dev/./urandom" \
+  -Dsonar.web.javaAdditionalOpts="${SONAR_WEB_JAVAOPTS:-$SONARQUBE_WEB_JVM_OPTS} -Djava.security.egd=file:/dev/./urandom" \
   "${sq_opts[@]}" \
   "$@"


### PR DESCRIPTION
The `SONARQUBE_*` environment variables used in older images have been
deprecated in favor of sticking with the `SONAR_*` equivalents (cf.
[MMF-1881](https://jira.sonarsource.com/browse/MMF-1881)). This deprecation was only applied to Dockerfiles for versions
8.x, which had the side effect of making it slightly harder for the Helm
chart to support both major versions out of the box.

This change allows the non-deprecated environment variables to be read
by the 7.9 LTS image, if present, without breaking existing behavior.

Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, try to make sure the images run correctly on Linux
