### PR TITLE
SONAR-15344 fontmanager missing in headless jre

### DIFF
--- a/9/community/Dockerfile
+++ b/9/community/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     addgroup -S -g 1000 sonarqube; \
     adduser -S -D -u 1000 -G sonarqube sonarqube; \
     apk add --no-cache --virtual build-dependencies gnupg unzip curl; \
-    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre-headless; \
+    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre; \
     # pub   2048R/D26468DE 2015-05-25
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>

--- a/9/datacenter/app/Dockerfile
+++ b/9/datacenter/app/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
     addgroup -S -g 1000 sonarqube; \
     adduser -S -D -u 1000 -G sonarqube sonarqube; \
     apk add --no-cache --virtual build-dependencies gnupg unzip curl; \
-    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre-headless; \
+    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre; \
     # pub   2048R/D26468DE 2015-05-25
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>

--- a/9/datacenter/search/Dockerfile
+++ b/9/datacenter/search/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
     addgroup -S -g 1000 sonarqube; \
     adduser -S -D -u 1000 -G sonarqube sonarqube; \
     apk add --no-cache --virtual build-dependencies gnupg unzip curl; \
-    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre-headless; \
+    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre; \
     # pub   2048R/D26468DE 2015-05-25
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>

--- a/9/developer/Dockerfile
+++ b/9/developer/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     addgroup -S -g 1000 sonarqube; \
     adduser -S -D -u 1000 -G sonarqube sonarqube; \
     apk add --no-cache --virtual build-dependencies gnupg unzip curl; \
-    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre-headless; \
+    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre; \
     # pub   2048R/D26468DE 2015-05-25
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>

--- a/9/enterprise/Dockerfile
+++ b/9/enterprise/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     addgroup -S -g 1000 sonarqube; \
     adduser -S -D -u 1000 -G sonarqube sonarqube; \
     apk add --no-cache --virtual build-dependencies gnupg unzip curl; \
-    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre-headless; \
+    apk add --no-cache bash su-exec ttf-dejavu openjdk11-jre; \
     # pub   2048R/D26468DE 2015-05-25
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>


### PR DESCRIPTION
dogfood background portfolio recomputation failed over the weekend with `java.lang.UnsatisfiedLinkError: no fontmanager in java.library.path`  probably due to the headless jre not containing a fontmanager