### PR TITLE
Fix running on M1 Mac

### DIFF
--- a/9/community/Dockerfile
+++ b/9/community/Dockerfile
@@ -51,6 +51,8 @@ RUN set -eux; \
     apk del --purge build-dependencies;
 
 COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
+RUN chmod +x ${SONARQUBE_HOME}/bin/run.sh
+RUN chmod +x ${SONARQUBE_HOME}/bin/sonar.sh
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000


### PR DESCRIPTION
Without making bin files executable, docker run fails on M1 mac