### PR TITLE
Create paths for environment variables' values

### DIFF
--- a/9/community/run.sh
+++ b/9/community/run.sh
@@ -20,6 +20,11 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [[ "$1" = '/opt/sonarqube/bin/sonar.sh' ]]; then
+    mkdir -p "${SQ_DATA_DIR}"
+    mkdir -p "${SQ_EXTENSIONS_DIR}"
+    mkdir -p "${SQ_LOGS_DIR}"
+    mkdir -p "${SQ_TEMP_DIR}"
+
     chown -R "$(id -u):$(id -g)" "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}" 2>/dev/null || :
     chmod -R 700 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}" 2>/dev/null || :
 


### PR DESCRIPTION
The motivation behind this fix is to allow me run sonarqube with docker by passing only one volume (instead of three). The reason I want this (although irrelevant) is because I am setting this up to run with Google Compute Engine.

As described in the commit message, you can override the paths via the env vars, but if they do not exist, the startup script fails [here](https://github.com/SonarSource/docker-sonarqube/blob/master/9/community/run.sh#L23). 

I have tested that my change works using the following script:

```
# before
$ docker run --rm --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 -v /tmp/sonarqube:/foo -e SQ_DATA_DIR="/foo/data" -e SQ_EXTENSIONS_DIR="/foo/extensions" -e SQ_LOGS_DIR="/foo/logs" sonarqube:latest
chown: /foo/data: No such file or directory
chown: /foo/extensions: No such file or directory
chown: /foo/logs: No such file or directory

# after
docker run --rm --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 -v /tmp/sonarqube:/foo -e SQ_DATA_DIR="/foo/data" -e SQ_EXTENSIONS_DIR="/foo/extensions" -e SQ_LOGS_DIR="/foo/logs" sonarqube:fragoulis
```

In addition I have run the tests:
```
$ ./build-and-run.sh 9/community
```

cc @ptkweller

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, try to make sure the images run correctly on Linux
