### PR TITLE
[NO-JIRA] Set up Slack alerts on GH Actions

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,6 +17,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Public Image test
         run: ./run-public-image-tests.sh
+      - name: Notify failures on Slack
+        if: failure()
+        uses: Ilshidur/action-slack@2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        with:
+          args: "Public Docker Image Build failed, see the logs at https://github.com/SonarSource/docker-sonarqube/actions"
 
   build_and_test:
     strategy:
@@ -54,6 +61,13 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os'
           severity: 'CRITICAL,HIGH'
+      - name: Notify failures on Slack
+        if: failure()
+        uses: Ilshidur/action-slack@2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        with:
+          args: "Docker Image Build failed, see the logs at https://github.com/SonarSource/docker-sonarqube/actions"
 
   build_and_test_dce:
     strategy:
@@ -90,3 +104,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os'
           severity: 'CRITICAL,HIGH'
+      - name: Notify failures on Slack
+        if: failure()
+        uses: Ilshidur/action-slack@2.0.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        with:
+          args: "Docker DCE Image Build failed, see the logs at https://github.com/SonarSource/docker-sonarqube/actions"


### PR DESCRIPTION
I'd like to make sure that we are notified on [#team-sq-devops](https://sonarsource.slack.com/archives/C0372LQ1N06) for whenever a GH action of this repo fails.

I don't have access to set up secrets on this repo. @tobias-trabelsi-sonarsource could you set that? The webhook url could be that of the [App](https://api.slack.com/apps/A0376E7S685/incoming-webhooks?) we created for this.

Side now: does anyone besides you @tobias-trabelsi-sonarsource have access to set up secrets for this repo?
