### PR TITLE
add permission and set to rootless for community Dockerfile

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -129,7 +129,12 @@ RUN set -eux; \
 
 COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
 
+RUN chmod 700 ${SONARQUBE_HOME}/bin/run.sh && chmod 700 ${SONARQUBE_HOME}/bin/sonar.sh
+
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
+
+USER sonarqube:sonarqube
+
 ENTRYPOINT ["bin/run.sh"]
 CMD ["bin/sonar.sh"]

--- a/9/community/Dockerfile
+++ b/9/community/Dockerfile
@@ -49,8 +49,12 @@ RUN set -eux; \
 
 COPY --chown=sonarqube:sonarqube run.sh sonar.sh ${SONARQUBE_HOME}/bin/
 
+RUN chmod 700 ${SONARQUBE_HOME}/bin/run.sh && chmod 700 ${SONARQUBE_HOME}/bin/sonar.sh
+
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
+
+USER sonarqube:sonarqube
 
 STOPSIGNAL SIGINT
 


### PR DESCRIPTION
The permission of run.sh and sonar.sh might be different than default.
Force to change the permission in Dockerfile could be more stable.
At the sametime, change the default user to sonarqube should be better.

After build and run on Linux and Kubernetes, everything is well.