### PR TITLE
Remove travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This is the Git repo of the official Docker image for [SonarQube](https://regist
 
 The full readme is generated over in [docker-library/docs](https://github.com/docker-library/docs), specifically in [docker-library/docs/sonarqube](https://github.com/docker-library/docs/tree/master/sonarqube).
 
-[![Build Status](https://travis-ci.org/SonarSource/docker-sonarqube.svg)](https://travis-ci.org/SonarSource/docker-sonarqube)
 
 Have Question or Feedback?
 --------------------------


### PR DESCRIPTION
Travis job was not run for two years, remove the useless badge from the readme.
