### PR TITLE
Replace status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# About this Repo
+# About this Repo [![QA](https://github.com/SonarSource/docker-sonarqube/actions/workflows/qa.yml/badge.svg)](https://github.com/SonarSource/docker-sonarqube/actions/workflows/qa.yml)
 
 This is the Git repo of the official Docker image for [SonarQube](https://registry.hub.docker.com/_/sonarqube/). See the Hub page for the full readme on how to use the Docker image and for information regarding contributing and issues.
 
 The full readme is generated over in [docker-library/docs](https://github.com/docker-library/docs), specifically in [docker-library/docs/sonarqube](https://github.com/docker-library/docs/tree/master/sonarqube).
-
-[![Build Status](https://travis-ci.org/SonarSource/docker-sonarqube.svg)](https://travis-ci.org/SonarSource/docker-sonarqube)
 
 Have Question or Feedback?
 --------------------------


### PR DESCRIPTION
Let's replace the status badge. We're not using Travis anymore, but use GitHub Actions.