### PR TITLE
add seccomp filter option in example `sq-with-postgres`

### DIFF
--- a/example-compose-files/sq-with-postgres/docker-compose.yml
+++ b/example-compose-files/sq-with-postgres/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_SEARCH_JAVAADDITIONALOPTS: -Dbootstrap.system_call_filter=false
     volumes:
       - sonarqube_data:/opt/sonarqube/data
       - sonarqube_extensions:/opt/sonarqube/extensions


### PR DESCRIPTION
## problem & motivation

In my environment I always get the following error and sonarqube does not start.

```
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.b.BootstrapChecks] explicitly enforcing bootstrap checks
sonarqube    |
sonarqube    | ERROR: [1] bootstrap checks failed. You must address the points described in the following [1] lines before starting Elasticsearch.
sonarqube    | bootstrap check failure [1] of [1]: system call filters failed to install; check the logs and fix your configuration or disable system call filters at your own risk
sonarqube    | ERROR: Elasticsearch did not exit normally - check the logs at /opt/sonarqube/logs/sonarqube.log
```

I think there is a need for a fix as there are other people who encounter the same problem.

https://github.com/SonarSource/docker-sonarqube/issues/402
https://community.sonarsource.com/t/failed-to-run-sonarqube-by-docker-compose-yml/52998

#### More Detail

PC: mac(apple-silicon)
OS: Monterey

(log)
```sh
xxxxx@macbook-air sq-with-postgres % docker-compose up --build
Starting postgresql ... done
Starting sonarqube  ... done
Attaching to postgresql, sonarqube
postgresql   |
postgresql   | PostgreSQL Database directory appears to contain a database; Skipping initialization
postgresql   |
postgresql   | 2022-11-04 10:41:42.730 UTC [1] LOG:  starting PostgreSQL 12.12 (Debian 12.12-1.pgdg110+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
postgresql   | 2022-11-04 10:41:42.734 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgresql   | 2022-11-04 10:41:42.734 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgresql   | 2022-11-04 10:41:42.738 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgresql   | 2022-11-04 10:41:42.751 UTC [26] LOG:  database system was shut down at 2022-11-04 10:41:39 UTC
postgresql   | 2022-11-04 10:41:42.755 UTC [1] LOG:  database system is ready to accept connections
sonarqube    | Dropping Privileges
sonarqube    | 2022.11.04 10:41:45 INFO  app[][o.s.a.AppFileSystem] Cleaning or creating temp directory /opt/sonarqube/temp
sonarqube    | 2022.11.04 10:41:45 INFO  app[][o.s.a.es.EsSettings] Elasticsearch listening on [HTTP: 127.0.0.1:9001, TCP: 127.0.0.1:32869]
sonarqube    | 2022.11.04 10:41:45 INFO  app[][o.s.a.ProcessLauncherImpl] Launch process[ELASTICSEARCH] from [/opt/sonarqube/elasticsearch]: /opt/sonarqube/elasticsearch/bin/elasticsearch
sonarqube    | 2022.11.04 10:41:45 INFO  app[][o.s.a.SchedulerImpl] Waiting for Elasticsearch to be up and running
sonarqube    | 2022.11.04 10:41:52 WARN  es[][o.e.b.JNANatives] unable to install syscall filter:
sonarqube    | java.lang.UnsupportedOperationException: seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed
sonarqube    | 	at org.elasticsearch.bootstrap.SystemCallFilter.linuxImpl(SystemCallFilter.java:347) ~[elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.SystemCallFilter.init(SystemCallFilter.java:638) ~[elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.JNANatives.tryInstallSystemCallFilter(JNANatives.java:255) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Natives.tryInstallSystemCallFilter(Natives.java:102) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Bootstrap.initializeNatives(Bootstrap.java:112) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:183) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:434) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:169) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:160) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:77) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:112) [elasticsearch-cli-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.cli.Command.main(Command.java:77) [elasticsearch-cli-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:125) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 	at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:80) [elasticsearch-7.17.5.jar:7.17.5]
sonarqube    | 2022.11.04 10:41:53 INFO  es[][o.e.n.Node] version[7.17.5], pid[73], build[default/tar/8d61b4f7ddf931f219e3745f295ed2bbc50c8e84/2022-06-23T21:57:28.736740635Z], OS[Linux/5.10.104-linuxkit/amd64], JVM[Alpine/OpenJDK 64-Bit Server VM/11.0.15/11.0.15+10-alpine-r0]
sonarqube    | 2022.11.04 10:41:53 INFO  es[][o.e.n.Node] JVM home [/usr/lib/jvm/java-11-openjdk]
sonarqube    | 2022.11.04 10:41:53 INFO  es[][o.e.n.Node] JVM arguments [-XX:+UseG1GC, -Djava.io.tmpdir=/opt/sonarqube/temp, -XX:ErrorFile=../logs/es_hs_err_pid%p.log, -Des.networkaddress.cache.ttl=60, -Des.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -Djna.tmpdir=/opt/sonarqube/temp, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Dlog4j2.formatMsgNoLookups=true, -Djava.locale.providers=COMPAT, -Dcom.redhat.fips=false, -Des.enforce.bootstrap.checks=true, -Xmx512m, -Xms512m, -XX:MaxDirectMemorySize=256m, -XX:+HeapDumpOnOutOfMemoryError, -Des.path.home=/opt/sonarqube/elasticsearch, -Des.path.conf=/opt/sonarqube/temp/conf/es, -Des.distribution.flavor=default, -Des.distribution.type=tar, -Des.bundled_jdk=false]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.p.PluginsService] loaded module [analysis-common]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.p.PluginsService] loaded module [lang-painless]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.p.PluginsService] loaded module [parent-join]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.p.PluginsService] loaded module [reindex]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.p.PluginsService] loaded module [transport-netty4]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.p.PluginsService] no plugins loaded
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.e.NodeEnvironment] using [1] data paths, mounts [[/opt/sonarqube/data (/dev/vda1)]], net usable_space [51.8gb], net total_space [58.4gb], types [ext4]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.e.NodeEnvironment] heap size [512mb], compressed ordinary object pointers [true]
sonarqube    | 2022.11.04 10:41:55 INFO  es[][o.e.n.Node] node name [sonarqube], node ID [PLT9GhJOTOKWnXwglc5caw], cluster name [sonarqube], roles [data_frozen, master, remote_cluster_client, data, data_content, data_hot, data_warm, data_cold, ingest]
sonarqube    | 2022.11.04 10:42:06 INFO  es[][o.e.t.NettyAllocator] creating NettyAllocator with the following configs: [name=unpooled, suggested_max_allocation_size=256kb, factors={es.unsafe.use_unpooled_allocator=null, g1gc_enabled=true, g1gc_region_size=1mb, heap_size=512mb}]
sonarqube    | 2022.11.04 10:42:07 INFO  es[][o.e.i.r.RecoverySettings] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]
sonarqube    | 2022.11.04 10:42:07 INFO  es[][o.e.d.DiscoveryModule] using discovery type [zen] and seed hosts providers [settings]
sonarqube    | 2022.11.04 10:42:09 INFO  es[][o.e.g.DanglingIndicesState] gateway.auto_import_dangling_indices is disabled, dangling indices will not be automatically detected or imported and must be managed manually
sonarqube    | 2022.11.04 10:42:09 INFO  es[][o.e.n.Node] initialized
sonarqube    | 2022.11.04 10:42:09 INFO  es[][o.e.n.Node] starting ...
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.t.TransportService] publish_address {127.0.0.1:32869}, bound_addresses {127.0.0.1:32869}
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.b.BootstrapChecks] explicitly enforcing bootstrap checks
sonarqube    |
sonarqube    | ERROR: [1] bootstrap checks failed. You must address the points described in the following [1] lines before starting Elasticsearch.
sonarqube    | bootstrap check failure [1] of [1]: system call filters failed to install; check the logs and fix your configuration or disable system call filters at your own risk
sonarqube    | ERROR: Elasticsearch did not exit normally - check the logs at /opt/sonarqube/logs/sonarqube.log
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.n.Node] stopping ...
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.n.Node] stopped
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.n.Node] closing ...
sonarqube    | 2022.11.04 10:42:10 INFO  es[][o.e.n.Node] closed
sonarqube    | 2022.11.04 10:42:10 WARN  app[][o.s.a.p.AbstractManagedProcess] Process exited with exit value [ElasticSearch]: 78
sonarqube    | 2022.11.04 10:42:10 INFO  app[][o.s.a.SchedulerImpl] Process[ElasticSearch] is stopped
sonarqube    | 2022.11.04 10:42:11 ERROR app[][o.s.a.p.EsManagedProcess] Failed to check status
sonarqube    | org.elasticsearch.ElasticsearchException: java.lang.InterruptedException
sonarqube    | 	at org.elasticsearch.client.RestHighLevelClient.performClientRequest(RestHighLevelClient.java:2695)
sonarqube    | 	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:2171)
sonarqube    | 	at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:2137)
sonarqube    | 	at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:2105)
sonarqube    | 	at org.elasticsearch.client.ClusterClient.health(ClusterClient.java:151)
sonarqube    | 	at org.sonar.application.es.EsConnectorImpl.getClusterHealthStatus(EsConnectorImpl.java:64)
sonarqube    | 	at org.sonar.application.process.EsManagedProcess.checkStatus(EsManagedProcess.java:92)
sonarqube    | 	at org.sonar.application.process.EsManagedProcess.checkOperational(EsManagedProcess.java:84)
sonarqube    | 	at org.sonar.application.process.EsManagedProcess.isOperational(EsManagedProcess.java:62)
sonarqube    | 	at org.sonar.application.process.ManagedProcessHandler.refreshState(ManagedProcessHandler.java:223)
sonarqube    | 	at org.sonar.application.process.ManagedProcessHandler$EventWatcher.run(ManagedProcessHandler.java:288)
sonarqube    | Caused by: java.lang.InterruptedException: null
sonarqube    | 	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1343)
sonarqube    | 	at org.elasticsearch.common.util.concurrent.BaseFuture$Sync.get(BaseFuture.java:243)
sonarqube    | 	at org.elasticsearch.common.util.concurrent.BaseFuture.get(BaseFuture.java:75)
sonarqube    | 	at org.elasticsearch.client.RestHighLevelClient.performClientRequest(RestHighLevelClient.java:2692)
sonarqube    | 	... 10 common frames omitted
sonarqube    | 2022.11.04 10:42:11 INFO  app[][o.s.a.SchedulerImpl] SonarQube is stopped
sonarqube exited with code 0
^CGracefully stopping... (press Ctrl+C again to force)
Stopping postgresql ... done
xxxxx@macbook-air sq-with-postgres %
```

## My Solution

add environment `SONAR_SEARCH_JAVAADDITIONALOPTS: -Dbootstrap.system_call_filter=false` in example `docker-compose.yml`

```yml
version: "3"
services:
  sonarqube:
    image: sonarqube:community
    hostname: sonarqube
    container_name: sonarqube
    depends_on:
      - db
    environment:
      SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
      SONAR_JDBC_USERNAME: sonar
      SONAR_JDBC_PASSWORD: sonar
      SONAR_SEARCH_JAVAADDITIONALOPTS: -Dbootstrap.system_call_filter=false #add this line
    volumes:
      - sonarqube_data:/opt/sonarqube/data
      - sonarqube_extensions:/opt/sonarqube/extensions
      - sonarqube_logs:/opt/sonarqube/logs
    ports:
      - "9000:9000"
  db:
    image: postgres:12
    hostname: postgresql
    container_name: postgresql
    environment:
      POSTGRES_USER: sonar
      POSTGRES_PASSWORD: sonar
      POSTGRES_DB: sonar
    volumes:
      - postgresql:/var/lib/postgresql
      - postgresql_data:/var/lib/postgresql/data

volumes:
  sonarqube_data:
  sonarqube_extensions:
  sonarqube_logs:
  postgresql:
  postgresql_data:

```

----

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works<br/>→ThisPR is not fix-image. So I don't use the `run-tests.sh imagedir` command 
- [ ] If the PR modifies or adds images, try to make sure the images run correctly on Linux <br/>→ThisPR is not fix-image.
