### PR TITLE
DOCKER-110 Install zlib through apk

### DIFF
--- a/8/community/Dockerfile
+++ b/8/community/Dockerfile
@@ -102,7 +102,7 @@ RUN set -eux; \
     addgroup -S -g 1000 sonarqube; \
     adduser -S -D -u 1000 -G sonarqube sonarqube; \
     apk add --no-cache --virtual build-dependencies gnupg unzip curl; \
-    apk add --no-cache bash su-exec ttf-dejavu; \
+    apk add --no-cache bash su-exec ttf-dejavu zlib; \
     # pub   2048R/D26468DE 2015-05-25
     #       Key fingerprint = F118 2E81 C792 9289 21DB  CAB4 CFCA 4A29 D264 68DE
     # uid                  sonarsource_deployer (Sonarsource Deployer) <infra@sonarsource.com>


### PR DESCRIPTION
In order to address DOCKER-110, we try to remove the "manual" installation of zlib on alpine, relying on the package manager.
