### PR TITLE
DOCKER-164: Add org.opencontainers.image.url label

### DIFF
--- a/9/community/Dockerfile
+++ b/9/community/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jre
 
+LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
+
 ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'

--- a/9/datacenter/app/Dockerfile
+++ b/9/datacenter/app/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jre
 
+LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
+
 ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'

--- a/9/datacenter/search/Dockerfile
+++ b/9/datacenter/search/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jre
 
+LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
+
 ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'

--- a/9/developer/Dockerfile
+++ b/9/developer/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jre
 
+LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
+
 ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'

--- a/9/enterprise/Dockerfile
+++ b/9/enterprise/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:17-jre
 
+LABEL org.opencontainers.image.url=https://github.com/SonarSource/sonar-scanner-cli-docker
+
 ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
Add the org.opencontainers.image.url label to the docker image.

These annotations are useful for people to manual use as well as for use by tools. For example, Snyk uses them in its UI and Renovate uses them to find release notes.

See: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

See: https://github.com/SonarSource/sonar-scanner-cli-docker/pull/160

---

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [X] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [ ] If the PR modifies or adds images, try to make sure the images run correctly on Linux
