### PR TITLE
[NO JIRA] Replace bugged openjdk-17 used to scan our images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,7 +74,7 @@ private_scan_task:
   login_script:
     - docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
   setup_script:
-    - apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre-headless
+    - apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre
     - curl -sSL https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar -o wss-unified-agent.jar
     - echo "docker.includes=${tag}" >> .cirrus/wss-unified-agent.config
   scan_script:
@@ -94,7 +94,7 @@ public_scan_task:
   ec2_instance:
     <<: *VM_TEMPLATE
   setup_script:
-    - apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre-headless
+    - apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre
     - curl -sSL https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar -o wss-unified-agent.jar
     - echo "docker.includes=${tag}" >> .cirrus/wss-unified-agent.config
   scan_script:


### PR DESCRIPTION
Our image scanning tasks fail because of [this bug](https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/2019908). The quickest fix is to replace the OpenJDK used in the setup of those tasks.

