### PR TITLE
Update docker-compose.yml

### DIFF
--- a/example-compose-files/sq-with-postgres/docker-compose.yml
+++ b/example-compose-files/sq-with-postgres/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     image: sonarqube:community
     hostname: sonarqube
     container_name: sonarqube
-    read_only: true
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
'Read only: true' is causing the the sonarqube container to fail to build, 
Docker is saying:  'sonarqube is trying to start in read only mode'
Removing it fixes the issues and lets the docker build properly.

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [x] If the PR modifies or adds images, try to make sure the images run correctly on Linux
