### PR TITLE
REL-3303 address reviewer comments removing no-op apt clean

### DIFF
--- a/10/community/Dockerfile
+++ b/10/community/Dockerfile
@@ -60,8 +60,7 @@ RUN set -eux; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
-    rm -rf /var/lib/apt/lists/*; \
-    apt-get clean;
+    rm -rf /var/lib/apt/lists/*;
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 

--- a/10/datacenter/app/Dockerfile
+++ b/10/datacenter/app/Dockerfile
@@ -60,8 +60,7 @@ RUN set -eux; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
-    rm -rf /var/lib/apt/lists/*; \
-    apt-get clean;
+    rm -rf /var/lib/apt/lists/*;
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 

--- a/10/datacenter/search/Dockerfile
+++ b/10/datacenter/search/Dockerfile
@@ -63,8 +63,7 @@ RUN set -eux; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip curl; \
-    rm -rf /var/lib/apt/lists/*; \
-    apt-get clean;
+    rm -rf /var/lib/apt/lists/*;
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 

--- a/10/developer/Dockerfile
+++ b/10/developer/Dockerfile
@@ -60,8 +60,7 @@ RUN set -eux; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
-    rm -rf /var/lib/apt/lists/*; \
-    apt-get clean;
+    rm -rf /var/lib/apt/lists/*;
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 

--- a/10/enterprise/Dockerfile
+++ b/10/enterprise/Dockerfile
@@ -60,8 +60,7 @@ RUN set -eux; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
-    rm -rf /var/lib/apt/lists/*; \
-    apt-get clean;
+    rm -rf /var/lib/apt/lists/*;
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 


### PR DESCRIPTION
As stated by docker official images maintainer, apt clean is not needed because the eclipse temurin base image uses hooks to every dpkg / apt command to clean afterward. Hence apt clean here is a no-op entry