### PR TITLE
NO-JIRA Fixes the release of the Docker image for version 10-community

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         tag:
+          - 10-community
           - 10-developer
           - 10-enterprise
           - 10-datacenter-app


### PR DESCRIPTION
After refactoring the GitHub workflow in the [PR](https://github.com/SonarSource/docker-sonarqube/pull/715), the `10-community` tag was mistakenly omitted from the job matrix.