### PR TITLE
NO-JIRA fix Dockerfile security

### DIFF
--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -7,6 +7,8 @@ LABEL io.openshift.non-scalable=true
 LABEL io.openshift.tags=sonarqube,static-code-analysis,code-quality,clean-code
 LABEL org.opencontainers.image.url=https://github.com/SonarSource/docker-sonarqube
 
+SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "xtrace", "-c"]
+
 ENV LANG='en_US.UTF-8' \
     LANGUAGE='en_US:en' \
     LC_ALL='en_US.UTF-8'
@@ -28,8 +30,7 @@ ENV DOCKER_RUNNING="true" \
 # Separate stage to use variable expansion
 ENV ES_TMPDIR="${SQ_TEMP_DIR}"
 
-RUN set -eux; \
-    deluser ubuntu; \
+RUN deluser ubuntu; \
     useradd --system --uid 1000 --gid 0 sonarqube; \
     apt-get update; \
     apt-get --no-install-recommends -y install \

--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -31,7 +31,8 @@ ENV DOCKER_RUNNING="true" \
 ENV ES_TMPDIR="${SQ_TEMP_DIR}"
 
 RUN deluser ubuntu; \
-    useradd --system --uid 1000 --gid 0 sonarqube; \
+    groupadd --gid 3000 sonarqube; \
+    useradd --uid 1000 --gid 3000 sonarqube; \
     apt-get update; \
     apt-get --no-install-recommends -y install \
         bash \
@@ -64,14 +65,16 @@ RUN deluser ubuntu; \
     apt-get remove -y gnupg unzip; \
     rm -rf /var/lib/apt/lists/*;
 
-VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
-
 COPY entrypoint.sh ${SONARQUBE_HOME}/docker/
+
+RUN chown -R sonarqube:sonarqube /opt/sonarqube
+USER sonarqube
+
+VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000
 
-USER sonarqube
 STOPSIGNAL SIGINT
 
 ENTRYPOINT ["/opt/sonarqube/docker/entrypoint.sh"]


### PR DESCRIPTION
### Description

This PR introduces updates to the Dockerfile for improved runtime security of the SonarQube container. The changes ensure the application can run as a non-root user and avoid writing to the root filesystem, which enhances isolation and security, particularly in Kubernetes environments.

---

### Changes Made

1. **Shell Directive**:
   - Introduced the `SHELL` directive with flags `errexit`, `nounset`, and `xtrace` to ensure robust error handling and debugging across the Dockerfile directives. This change prevents common scripting pitfalls and ensures more predictable behavior in the container build process.

2. **User and Group Management**:
   - Replaced the previous `useradd` command to create a dedicated `sonarqube` group with GID 3000, and assigned the `sonarqube` user to this group. This ensures that the `sonarqube` user does not run with a GID of 0 (root group), enhancing security.

3. **File Ownership**:
   - Updated ownership of `/opt/sonarqube` to the `sonarqube` user and group using `chown`.  This ensures that the application does not attempt to write to root-owned directories, avoiding potential privilege escalations.

4. **Reordered Dockerfile Instructions**:
   - Moved the `USER sonarqube` declaration closer to where the user is set up to improve readability and maintain consistency.

---

### Motives and Benefits

- **Improved Security**:
  - Running the application as a non-root user minimizes potential attack vectors and aligns with best practices for containerized applications.
  - Proper user and group segregation reduces the risk of privilege escalation.

- **Kubernetes Compatibility**:
  - Running as non-root makes the container Kubernetes-compliant, as many clusters enforce non-root execution policies for workloads. Still work for already in-place deployments.

- **Filesystem Isolation**:
  - Ensuring that `sonarqube` does not write to the root filesystem enhances container isolation and data integrity.
  
It allows such Kubernetes directives in deployment manifest (non-mandatory):
```yaml
          securityContext:
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: true
            runAsGroup: 3000
            runAsNonRoot: true
            runAsUser: 1000
```

---

### Checklist

- [x] **Explain the motive for the contribution**: Improving security, isolation, and Kubernetes compatibility.
- [x] **If images were modified, verify they work**: Verified via `run-tests.sh imagedir.`.
- [x] **Test on Linux**: Ensure images run correctly on Linux.

---

Many thanks for reviewing this PR and for your time!