### PR TITLE
SONAR-24186 improve file ownership

### DIFF
--- a/2025.1/datacenter/app/Dockerfile
+++ b/2025.1/datacenter/app/Dockerfile
@@ -59,6 +59,8 @@ RUN set -eux; \
     rm sonarqube.zip*; \
     rm -rf ${SONARQUBE_HOME}/bin/*; \
     ln -s "${SONARQUBE_HOME}/lib/sonar-application-${SONARQUBE_VERSION}.jar" "${SONARQUBE_HOME}/lib/sonarqube.jar"; \
+    chown -R sonarqube:root ${SONARQUBE_HOME}; \
+    chown -R sonarqube:root "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
@@ -66,7 +68,7 @@ RUN set -eux; \
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 
-COPY run.sh sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --chown=sonarqube:root --chmod=550 run.sh sonar.sh ${SONARQUBE_HOME}/docker/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000

--- a/2025.1/datacenter/search/Dockerfile
+++ b/2025.1/datacenter/search/Dockerfile
@@ -62,6 +62,8 @@ RUN set -eux; \
     rm sonarqube.zip*; \
     rm -rf ${SONARQUBE_HOME}/bin/*; \
     ln -s "${SONARQUBE_HOME}/lib/sonar-application-${SONARQUBE_VERSION}.jar" "${SONARQUBE_HOME}/lib/sonarqube.jar"; \
+    chown -R sonarqube:root ${SONARQUBE_HOME}; \
+    chown -R sonarqube:root "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip curl; \
@@ -69,7 +71,7 @@ RUN set -eux; \
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 
-COPY run.sh sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --chown=sonarqube:root --chmod=550 run.sh sonar.sh ${SONARQUBE_HOME}/docker/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000

--- a/2025.1/developer/Dockerfile
+++ b/2025.1/developer/Dockerfile
@@ -58,6 +58,8 @@ RUN set -eux; \
     rm sonarqube.zip*; \
     rm -rf ${SONARQUBE_HOME}/bin/*; \
     ln -s "${SONARQUBE_HOME}/lib/sonar-application-${SONARQUBE_VERSION}.jar" "${SONARQUBE_HOME}/lib/sonarqube.jar"; \
+    chown -R sonarqube:root ${SONARQUBE_HOME}; \
+    chown -R sonarqube:root "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
@@ -65,7 +67,7 @@ RUN set -eux; \
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 
-COPY entrypoint.sh ${SONARQUBE_HOME}/docker/
+COPY --chown=sonarqube:root --chmod=550 entrypoint.sh ${SONARQUBE_HOME}/docker/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000

--- a/2025.1/enterprise/Dockerfile
+++ b/2025.1/enterprise/Dockerfile
@@ -58,6 +58,8 @@ RUN set -eux; \
     rm sonarqube.zip*; \
     rm -rf ${SONARQUBE_HOME}/bin/*; \
     ln -s "${SONARQUBE_HOME}/lib/sonar-application-${SONARQUBE_VERSION}.jar" "${SONARQUBE_HOME}/lib/sonarqube.jar"; \
+    chown -R sonarqube:root ${SONARQUBE_HOME}; \
+    chown -R sonarqube:root "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
@@ -65,7 +67,7 @@ RUN set -eux; \
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 
-COPY entrypoint.sh ${SONARQUBE_HOME}/docker/
+COPY --chown=sonarqube:root --chmod=550 entrypoint.sh ${SONARQUBE_HOME}/docker/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000

--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -58,6 +58,8 @@ RUN set -eux; \
     rm sonarqube.zip*; \
     rm -rf ${SONARQUBE_HOME}/bin/*; \
     ln -s "${SONARQUBE_HOME}/lib/sonar-application-${SONARQUBE_VERSION}.jar" "${SONARQUBE_HOME}/lib/sonarqube.jar"; \
+    chown -R sonarqube:root ${SONARQUBE_HOME}; \
+    chown -R sonarqube:root "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     chmod -R 550 ${SONARQUBE_HOME}; \
     chmod -R 770 "${SQ_DATA_DIR}" "${SQ_EXTENSIONS_DIR}" "${SQ_LOGS_DIR}" "${SQ_TEMP_DIR}"; \
     apt-get remove -y gnupg unzip; \
@@ -65,7 +67,7 @@ RUN set -eux; \
 
 VOLUME ["${SQ_DATA_DIR}", "${SQ_EXTENSIONS_DIR}", "${SQ_LOGS_DIR}", "${SQ_TEMP_DIR}"]
 
-COPY entrypoint.sh ${SONARQUBE_HOME}/docker/
+COPY --chown=sonarqube:root --chmod=550 entrypoint.sh ${SONARQUBE_HOME}/docker/
 
 WORKDIR ${SONARQUBE_HOME}
 EXPOSE 9000

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -68,7 +68,7 @@ wait_for_sonarqube() {
 wait_for_sonarqube_dce() {
     local image=$1-app i web_up=no sonarqube_up=no
 
-    for ((i = 0; i < 80; i++)); do
+    for ((i = 0; i < 90; i++)); do
         info "$image: waiting for web server to start ..."
         if curl -sI localhost:$port | grep '^HTTP/.* 200'; then
             web_up=yes
@@ -79,7 +79,7 @@ wait_for_sonarqube_dce() {
 
     [[ $web_up = yes ]] || return 1
 
-    for ((i = 0; i < 80; i++)); do
+    for ((i = 0; i < 90; i++)); do
         info "$image: waiting for sonarqube to be ready ..."
         if curl -s localhost:$port/api/system/status | grep '"status":"UP"'; then
             sonarqube_up=yes

--- a/tests/dce-compose-test/docker-compose.yml
+++ b/tests/dce-compose-test/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         test: wget --no-proxy -qO- "http://$$SONAR_CLUSTER_NODE_NAME:9001/_cluster/health?wait_for_status=yellow&timeout=50s" | grep -q -e '"status":"green"' -e '"status":"yellow"';  if [ $$? -eq 0 ]; then exit 0; else exit 1; fi
         interval: 25s
         timeout: 1s
-        retries: 3
+        retries: 9
         start_period: 55s
   db:
     image: postgres:12


### PR DESCRIPTION
[SONAR-24186](https://sonarsource.atlassian.net/browse/SONAR-24186)

We identified that we were not covering all options for runAsUser and runAsGroup in kubernetes context.

By adding ownership of files to sonarqube user we are compatible with both those workflow:

the current openshift behavior which is anyUid and gid=0
More classic use case were people rely on UID of the image (1000 in our case) but with gid!=0

Those two workflow will work as permissions are assigned to both owner and group.

[SONAR-24186]: https://sonarsource.atlassian.net/browse/SONAR-24186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ