### PR TITLE
Update postgres to version 17

### DIFF
--- a/example-compose-files/sq-with-postgres/docker-compose.yml
+++ b/example-compose-files/sq-with-postgres/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - ${NETWORK_TYPE:-ipv4}
   db:
-    image: postgres:15
+    image: postgres:17
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 10s


### PR DESCRIPTION
The currently (by example) proposed version of PostgreSQL is 15. The newer version 17 is already available for two years. The new SonarQube LTA should be used a version of the database with the latest EOL date.
Version 17 is supported according to the [documentation](https://docs.sonarsource.com/sonarqube-server/latest/setup-and-upgrade/installation-requirements/database-requirements/).

Please be aware that we are not actively looking for feature contributions. We typically accept minor improvements and bug-fixes. 
Please ensure your pull request adheres to the following guidelines:
- [x] explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] If the PR modifies or adds images, use the `run-tests.sh imagedir` command to verify the image works
- [ ] If the PR modifies or adds images, try to make sure the images run correctly on Linux
