### PR TITLE
SONAR-24570 Update the Community Build base image to use Java 21

### DIFF
--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-noble
+FROM eclipse-temurin:21-jre-noble
 
 LABEL io.k8s.description="SonarQube Community Build is a self-managed, automatic code review tool that systematically helps you deliver Clean Code."
 LABEL io.openshift.min-cpu=400m


### PR DESCRIPTION
[SONAR-24570](https://sonarsource.atlassian.net/browse/SONAR-24570)

Part of SONAR-24175

[SONAR-24570]: https://sonarsource.atlassian.net/browse/SONAR-24570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ