### PR TITLE
REL-3799 Release SonarQube Server 2025.3.1

### DIFF
--- a/.cirrus/tasks.yml
+++ b/.cirrus/tasks.yml
@@ -15,7 +15,7 @@ env:
   GCLOUD_PRODUCT_NAME: official-sonarqube-data-center-edition
   GCLOUD_STAGING_REGISTRY: gcr.io/sonarqube-marketplace-provider
   GCLOUD_STAGING_PRODUCT_NAME: sonarqube-dce-staging
-  CURRENT_VERSION: 2025.3.0
+  CURRENT_VERSION: 2025.3.1
   # We keep the previous LTA support for the next 6 months
   PREVIOUS_LTA_VERSION: 9.9.9
 

--- a/commercial-editions/datacenter/app/Dockerfile
+++ b/commercial-editions/datacenter/app/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.3.0.108892
+ARG SONARQUBE_VERSION=2025.3.1.109879
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/datacenter/search/Dockerfile
+++ b/commercial-editions/datacenter/search/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.3.0.108892
+ARG SONARQUBE_VERSION=2025.3.1.109879
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/developer/Dockerfile
+++ b/commercial-editions/developer/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.3.0.108892
+ARG SONARQUBE_VERSION=2025.3.1.109879
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/enterprise/Dockerfile
+++ b/commercial-editions/enterprise/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.3.0.108892
+ARG SONARQUBE_VERSION=2025.3.1.109879
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/release.md
+++ b/release.md
@@ -6,7 +6,7 @@ We consider the **docker image** as part of the SonarQube Server **product**. Th
 
 ## Overview
 
-Release of a new version of the official SonarQube Server Docker images is made of several operations. (Please note that in case of a patch release that should not include the latest changes on master, you need to release from a new branch - e.g., `release/10.8.1` - and propagate the changes to master afterwards).
+Release of a new version of the official SonarQube Server Docker images is made of several operations. (Please note that in case of an LTA patch release that should not include the latest changes on master, you need to release from a new branch - e.g., `release/2025.4` - and propagate the changes to master afterwards).
 
 1. Set the new version of SonarQube Server (`SONARQUBE_VERSION`) to be released in the Dockerfiles. In case of community build, please remember to update `community-build/Dockerfile` only.
 2. If you are releasing a new LTA, set `CURRENT_LTA_VERSION` in `.cirrus/tasks.yml`. Otherwise, if you are releasing a Community build, set `COMMUNITY_BUILD_VERSION` only. In all the other cases where a paid edition is about to be releases, set `CURRENT_VERSION` (please note that the nightly build will fail before the public image becomes available).


### PR DESCRIPTION
[REL-3799](https://sonarsource.atlassian.net/browse/REL-3799)



[REL-3799]: https://sonarsource.atlassian.net/browse/REL-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ