### PR TITLE
BUILD-8875: Migrate to standardized GitHub runner names

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/gcp-build-template.yml
+++ b/.github/workflows/gcp-build-template.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   gcp-build:
     name: GCP build ${{ inputs.build_type }} (${{ inputs.component_type }})
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/mend-scan-template.yml
+++ b/.github/workflows/mend-scan-template.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   mend-scan:
     name: Mend scan (${{ matrix.tag }})
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     strategy:
       matrix:
         tag: ${{ fromJSON(inputs.tags) }}

--- a/.github/workflows/multi-arch-build-commercial-editions.yml
+++ b/.github/workflows/multi-arch-build-commercial-editions.yml
@@ -45,4 +45,4 @@ jobs:
       staging_image_name: ${{ needs.load-config.outputs.staging_image }}
       tag: ${{ needs.load-config.outputs.current_version }}-master-${{ matrix.edition }}
       version: ${{ matrix.version }}
-      runs_on: ubuntu-latest-large
+      runs_on: github-ubuntu-latest-s

--- a/.github/workflows/multi-arch-build-community-build.yml
+++ b/.github/workflows/multi-arch-build-community-build.yml
@@ -39,4 +39,4 @@ jobs:
       staging_image_name: ${{ needs.load-config.outputs.staging_image }}
       tag: ${{ needs.load-config.outputs.community_build_version }}-master-${{ matrix.edition }}
       version: ${{ matrix.version }}
-      runs_on: ubuntu-latest-large
+      runs_on: github-ubuntu-latest-s

--- a/.github/workflows/multi-arch-build-template.yml
+++ b/.github/workflows/multi-arch-build-template.yml
@@ -24,7 +24,7 @@ on:
         required: false
         type: string
         description: "The runner to use"
-        default: "ubuntu-latest-large"
+        default: "github-ubuntu-latest-s"
 
 jobs:
   multi-arch-build:

--- a/.github/workflows/multi-arch-test-commercial-editions.yml
+++ b/.github/workflows/multi-arch-test-commercial-editions.yml
@@ -46,4 +46,4 @@ jobs:
       tag: ${{ needs.load-config.outputs.current_version }}-master-${{ matrix.edition }}
       test_name: ${{ matrix.test_name }}
       architecture: ${{ matrix.architecture }}
-      runs_on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm-large' || 'ubuntu-24.04-large' }}
+      runs_on: ${{ matrix.architecture == 'arm64' && 'github-ubuntu-24.04-arm-s' || 'github-ubuntu-latest-s' }}

--- a/.github/workflows/multi-arch-test-community-build.yml
+++ b/.github/workflows/multi-arch-test-community-build.yml
@@ -31,4 +31,4 @@ jobs:
       tag: ${{ needs.load-config.outputs.community_build_version }}-master-${{ matrix.edition }}
       test_name: ${{ matrix.test_name }}
       architecture: ${{ matrix.architecture }}
-      runs_on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm-large' || 'ubuntu-24.04-large' }}
+      runs_on: ${{ matrix.architecture == 'arm64' && 'github-ubuntu-24.04-arm-s' || 'github-ubuntu-latest-s' }}

--- a/.github/workflows/multi-arch-test-template.yml
+++ b/.github/workflows/multi-arch-test-template.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
         description: "The runner to use"
-        default: "ubuntu-latest-large"
+        default: "github-ubuntu-latest-s"
 
 jobs:
   multi-arch-test:

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -14,7 +14,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: ubuntu-latest-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - name: Send Slack Notification
         env:

--- a/docker-official-images/active_versions.json
+++ b/docker-official-images/active_versions.json
@@ -16,10 +16,5 @@
         {
             "branch": "origin/master",
             "type": "communityBuild"
-        },
-        {
-            "branch": "origin/master",
-            "type": "legacy",
-            "isLatestLTSTag": true
         }
 ]

--- a/docker-official-images/fixtures/active_versions.json
+++ b/docker-official-images/fixtures/active_versions.json
@@ -15,11 +15,5 @@
             "branch": "origin/master",
             "commitSha": "0330278146e14fdbde39328ab2c9e10a66f9fbe8",
             "type": "communityBuild"
-        },
-        {
-            "branch": "origin/master",
-            "commitSha": "0330278146e14fdbde39328ab2c9e10a66f9fbe8",
-            "type": "legacy",
-            "isLatestLTSTag": true
         }
 ]

--- a/docker-official-images/fixtures/docker-official-sonarqube
+++ b/docker-official-images/fixtures/docker-official-sonarqube
@@ -48,28 +48,3 @@ Tags: 25.6.0.109173-community, community, latest
 Directory: community-build
 GitCommit: 0330278146e14fdbde39328ab2c9e10a66f9fbe8
 GitFetch: refs/heads/master
-
-Tags: 9.9.8-community, 9.9-community, 9-community, lts, lts-community
-Directory: 9/community
-GitCommit: 0330278146e14fdbde39328ab2c9e10a66f9fbe8
-GitFetch: refs/heads/master
-
-Tags: 9.9.8-developer, 9.9-developer, 9-developer, lts-developer
-Directory: 9/developer
-GitCommit: 0330278146e14fdbde39328ab2c9e10a66f9fbe8
-GitFetch: refs/heads/master
-
-Tags: 9.9.9-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
-Directory: 9/enterprise
-GitCommit: 0330278146e14fdbde39328ab2c9e10a66f9fbe8
-GitFetch: refs/heads/master
-
-Tags: 9.9.9-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
-Directory: 9/datacenter/app
-GitCommit: 0330278146e14fdbde39328ab2c9e10a66f9fbe8
-GitFetch: refs/heads/master
-
-Tags: 9.9.9-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
-Directory: 9/datacenter/search
-GitCommit: 0330278146e14fdbde39328ab2c9e10a66f9fbe8
-GitFetch: refs/heads/master


### PR DESCRIPTION
[BUILD-8875](https://sonarsource.atlassian.net/browse/BUILD-8875)

## GitHub Actions Runner Migration

This PR updates GitHub Actions workflows to use our new standardized runner naming convention.

### Changes
- Updates runner names in workflow files to new standardized format
- No functional changes to your CI/CD pipelines
- All existing functionality remains identical

### Runner Mappings
| Old Runner | New Runner |
|------------|------------|
| sonar-runner-large | github-ubuntu-latest-s |
| ubuntu-latest-large | github-ubuntu-latest-s |
| windows-latest-large | github-windows-latest-s |
| ubuntu-24.04-large | github-ubuntu-latest-s |
| sonar-runner-large-arm | github-ubuntu-24.04-arm-s |
| ubuntu-24.04-arm-large | github-ubuntu-24.04-arm-s |

### What You Need to Do
1. Review the changes in this PR
2. Merge when ready - no additional action required
3. Old runners will remain available during transition

### Additional Information
For more details about GitHub Actions runners and their specifications, see our [GitHub Actions Runner Documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runner+-+GitHub).

This is an automated migration. Questions? Contact the **Engineering Experience squad**.


[BUILD-8875]: https://sonarsource.atlassian.net/browse/BUILD-8875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ