### PR TITLE
REL-3985 remove 9.9 support on docker images

### DIFF
--- a/docker-official-images/active_versions.json
+++ b/docker-official-images/active_versions.json
@@ -16,10 +16,5 @@
         {
             "branch": "origin/master",
             "type": "communityBuild"
-        },
-        {
-            "branch": "origin/master",
-            "type": "legacy",
-            "isLatestLTSTag": true
         }
 ]


### PR DESCRIPTION
[REL-3985](https://sonarsource.atlassian.net/browse/REL-3985)



[REL-3985]: https://sonarsource.atlassian.net/browse/REL-3985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ