### PR TITLE
SONAR-27393 Use major version tags for SonarSource GitHub Actions

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -21,7 +21,7 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/RequestReview@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/RequestReview@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -23,7 +23,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -43,21 +43,21 @@ jobs:
         name: docker-official-images-coverage-${{ github.sha }}
         path: docker-official-images/
     - name: SonarQube Next Scan
-      uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+      uses: sonarsource/sonarqube-scan-action@v7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).sq_next_token }}
         SONAR_HOST_URL: https://next.sonarqube.com/sonarqube/
     - name: SonarQube Cloud EU Scan
       if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+      uses: sonarsource/sonarqube-scan-action@v7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).sq_cloud_eu_token }}
         SONAR_HOST_URL: https://sonarcloud.io
     - name: SonarQube Cloud US Scan
       if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+      uses: sonarsource/sonarqube-scan-action@v7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).sq_cloud_us_token }}


### PR DESCRIPTION
## Summary
Replace SHA-pinned SonarSource GitHub Actions with major version tags.

SHA pinning causes the Request Review workflow to fail when the action is updated.

## Changes
- `sonarsource/gh-action-lt-backlog` `02f0a8d3...` → `@v2`
- `sonarsource/sonarqube-scan-action` `a31c9398...` → `@v7`