### PR TITLE
docker-compose: Fix Postgres volume mount

### DIFF
--- a/example-compose-files/sq-with-postgres/docker-compose.yml
+++ b/example-compose-files/sq-with-postgres/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       POSTGRES_PASSWORD: sonar
       POSTGRES_DB: sonar
     volumes:
-      - postgresql:/var/lib/postgresql
+      - postgresql:/var/lib/postgresql/data
     networks:
       - ${NETWORK_TYPE:-ipv4}
 


### PR DESCRIPTION
https://github.com/docker-library/docs/blob/ea45618e3609152fb315e85c2ee8678e3a4a9324/postgres/README.md?plain=1#L216

> **Important Note:** (for PostgreSQL 17 and below) Mount the data volume at `/var/lib/postgresql/data` and not at `/var/lib/postgresql` because mounts at the latter path WILL NOT PERSIST database data when the container is re-created. The Dockerfile that builds the image declares a volume at `/var/lib/postgresql/data` and if no data volume is mounted at that path then the container runtime will automatically create an [anonymous volume](https://docs.docker.com/engine/storage/#volumes) that is not reused across container re-creations. Data will be written to the anonymous volume rather than your intended data volume and won't persist when the container is deleted and re-created.

If you are frantically searching for your lost postgres data, look in /var/lib/docker/volumes for it:
```
find /var/lib/docker/volumes/ -type d -name base
```

Then copy the contents to the empty named volume:
```
docker compose stop
VOL=<name of the volume>
docker run --rm   -v $VOL:/from   -v sonarqube-self-hosted_postgresql:/to   alpine sh -c "cp -av /from/. /to/"
docker compose up
```
