### PR TITLE
REL-4573: Release SonarQube Community Build 26.5

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -3,7 +3,7 @@
 
 versions:
   current: "2026.2.0"
-  community_build: "26.4.0.121862"
+  community_build: "26.5.0.122743"
 
 images:
   staging: "sonarsource/sonarqube"

--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=26.4.0.121862
+ARG SONARQUBE_VERSION=26.5.0.122743
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \


### PR DESCRIPTION
## Summary

Release SonarQube Community Build 26.5 (`26.5.0.122743`).

## Changes

- `.github/github_env.yaml`: bump `community_build` from `26.4.0.121862` to `26.5.0.122743`
- `community-build/Dockerfile`: bump default `SONARQUBE_VERSION` from `26.4.0.121862` to `26.5.0.122743`

Jira: https://sonarsource.atlassian.net/browse/REL-4573