### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/gcp-build-template.yml
+++ b/.github/workflows/gcp-build-template.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   gcp-build:
     name: GCP build ${{ inputs.build_type }} (${{ inputs.component_type }})
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/go-test-template.yml
+++ b/.github/workflows/go-test-template.yml
@@ -4,7 +4,7 @@ on:
 name: go test the official images generator
 jobs:
   go-test:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/multi-arch-build-template.yml
+++ b/.github/workflows/multi-arch-build-template.yml
@@ -24,7 +24,7 @@ on:
         required: false
         type: string
         description: "The runner to use"
-        default: "github-ubuntu-latest-s"
+        default: "warp-custom-ubuntu-24-04"
 
 jobs:
   multi-arch-build:

--- a/.github/workflows/multi-arch-test-template.yml
+++ b/.github/workflows/multi-arch-test-template.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
         description: "The runner to use"
-        default: "github-ubuntu-latest-s"
+        default: "warp-custom-ubuntu-24-04"
 
 jobs:
   multi-arch-test:

--- a/.github/workflows/push_and_pr.yml
+++ b/.github/workflows/push_and_pr.yml
@@ -120,7 +120,7 @@ jobs:
       staging_image_name: ${{ needs.load-config.outputs.staging_image }}
       tag: ${{ needs.load-config.outputs.current_version }}-master-${{ matrix.edition }}
       version: ${{ matrix.version }}
-      runs_on: github-ubuntu-latest-s
+      runs_on: warp-custom-ubuntu-24-04
 
   build-community-build:
     needs: load-config
@@ -136,7 +136,7 @@ jobs:
       staging_image_name: ${{ needs.load-config.outputs.staging_image }}
       tag: ${{ needs.load-config.outputs.community_build_version }}-master-community
       version: community-build
-      runs_on: github-ubuntu-latest-s
+      runs_on: warp-custom-ubuntu-24-04
 
   # Test phase - runs immediately after builds complete (no workflow_run delay)
   test-commercial-editions:
@@ -176,7 +176,7 @@ jobs:
       tag: ${{ needs.load-config.outputs.current_version }}-master-${{ matrix.edition }}
       test_name: ${{ matrix.test_name }}
       architecture: ${{ matrix.architecture }}
-      runs_on: ${{ matrix.architecture == 'arm64' && 'github-ubuntu-24.04-arm-s' || 'github-ubuntu-latest-s' }}
+      runs_on: ${{ matrix.architecture == 'arm64' && 'github-ubuntu-24.04-arm-s' || 'warp-custom-ubuntu-24-04' }}
 
   test-community-build:
     needs: [load-config, build-community-build]
@@ -197,7 +197,7 @@ jobs:
       tag: ${{ needs.load-config.outputs.community_build_version }}-master-community
       test_name: docker
       architecture: ${{ matrix.architecture }}
-      runs_on: ${{ matrix.architecture == 'arm64' && 'github-ubuntu-24.04-arm-s' || 'github-ubuntu-latest-s' }}
+      runs_on: ${{ matrix.architecture == 'arm64' && 'github-ubuntu-24.04-arm-s' || 'warp-custom-ubuntu-24-04' }}
 
   # Security scanning - runs after builds complete
   trivy-scan-datacenter-app:
@@ -206,7 +206,7 @@ jobs:
       always() &&
       (github.event_name != 'workflow_dispatch' || inputs.editions == 'all' || inputs.editions == 'commercial-only')
     name: Security Scan (datacenter-app)
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -301,7 +301,7 @@ jobs:
       - trivy-scan-datacenter-app
       - gcp-build-staging-app
       - gcp-build-staging-search
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     outputs:
       SUCCESS: ${{ steps.alls-green.outputs.success }}
     steps:

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -8,7 +8,7 @@ jobs:
     name: Slack Notification
     permissions:
       id-token: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Vault Secrets
         id: secrets

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -19,7 +19,7 @@ jobs:
   go-test:
     uses: ./.github/workflows/go-test-template.yml
   sonarqube:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     needs: go-test
     permissions:
       id-token: write


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows touched by this migration.

## Files

- `.github/workflows/gcp-build-template.yml`
- `.github/workflows/go-test-template.yml`
- `.github/workflows/multi-arch-build-template.yml`
- `.github/workflows/multi-arch-test-template.yml`
- `.github/workflows/push_and_pr.yml`
- `.github/workflows/slack_notify.yml`
- `.github/workflows/sonarqube-scan.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
