### PR TITLE
Bump SonarQube Community Build to 26.5.0.122824

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -3,7 +3,7 @@
 
 versions:
   current: "2026.3.0"
-  community_build: "26.5.0.122743"
+  community_build: "26.5.0.122824"
 
 images:
   staging: "sonarsource/sonarqube"

--- a/.github/workflows/community-build-version-bump.yml
+++ b/.github/workflows/community-build-version-bump.yml
@@ -18,21 +18,15 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
-
       - name: 'Checkout repository'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2
         with:
           persist-credentials: true
-          token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: 'Bump SONARQUBE_VERSION and create PR'
         env:
-          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           NEW_VERSION: ${{ github.event.client_payload.community_build_version || github.event.inputs.community_build_version }}
         run: |
           if [ -z "$NEW_VERSION" ]; then

--- a/.github/workflows/community-build-version-bump.yml
+++ b/.github/workflows/community-build-version-bump.yml
@@ -22,7 +22,7 @@ jobs:
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-release-automation token | GITHUB_TOKEN;
+            development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
 
       - name: 'Checkout repository'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v6.0.2

--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=26.5.0.122743
+ARG SONARQUBE_VERSION=26.5.0.122824
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \


### PR DESCRIPTION
Automated version bump triggered by community-build release in sonar-enterprise.