### PR TITLE
Bump SonarQube Community Build to 26.5.0.122824

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -3,7 +3,7 @@
 
 versions:
   current: "2026.3.0"
-  community_build: "26.5.0.122743"
+  community_build: "26.5.0.122824"
 
 images:
   staging: "sonarsource/sonarqube"

--- a/community-build/Dockerfile
+++ b/community-build/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=26.5.0.122743
+ARG SONARQUBE_VERSION=26.5.0.122824
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \


### PR DESCRIPTION
Automated version bump triggered by community-build release.