### PR TITLE
REL-4630 Release SQS 2025.1.8

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -2,7 +2,7 @@
 # This file contains all version numbers and common configurations used across workflows
 
 versions:
-  current: "2025.1.7"
+  current: "2025.1.8"
 
 images:
   staging: "sonarsource/sonarqube"

--- a/commercial-editions/datacenter/app/Dockerfile
+++ b/commercial-editions/datacenter/app/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.1.7.121414
+ARG SONARQUBE_VERSION=2025.1.8.123366
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/datacenter/search/Dockerfile
+++ b/commercial-editions/datacenter/search/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.1.7.121414
+ARG SONARQUBE_VERSION=2025.1.8.123366
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/developer/Dockerfile
+++ b/commercial-editions/developer/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.1.7.121414
+ARG SONARQUBE_VERSION=2025.1.8.123366
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/enterprise/Dockerfile
+++ b/commercial-editions/enterprise/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.1.7.121414
+ARG SONARQUBE_VERSION=2025.1.8.123366
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2025.1.7-datacenter-app
+FROM sonarqube:2025.1.8-datacenter-app
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2025.1.7-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2025.1.8-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-app.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2025.1.7-datacenter-search
+FROM sonarqube:2025.1.8-datacenter-search
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2025.1.7-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2025.1.8-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-search.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/README.md
+++ b/example-compose-files/sq-dce-custom-zip-postgres/README.md
@@ -16,11 +16,11 @@ ls -al
 11:33 Dockerfile-search
 11:39 README
 11:37 docker-compose.yml
-11:33 sonarqube-datacenter-2025.1.7.121414.zip
+11:33 sonarqube-datacenter-2025.1.8.123366.zip
 11:33 unrestricted_client_body_size.conf
 ```
 
-You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2025.1.7.121414` or by changing the docker-compose file.
+You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2025.1.8.123366` or by changing the docker-compose file.
 
 You can then run this command to start the SonarQube Server instance:
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
  - Update SonarQube version to `2025.1.8` in `github_env.yaml` and throughout `commercial-editions` Dockerfiles.
- **Configuration updates:**
  - Synchronize `example-compose-files` with the new version by updating `Dockerfile-app`, `Dockerfile-search`, and `README.md`.

<sub>This will update automatically on new commits.</sub>