### PR TITLE
SONAR-24340 Resolve DCE cluster node IP for IPv4 and IPv6

### DIFF
--- a/commercial-editions/datacenter/app/run.sh
+++ b/commercial-editions/datacenter/app/run.sh
@@ -14,8 +14,8 @@ discover_ip() {
     fi
 }
 
-# Resolve this node's cluster IP. In Kubernetes the Helm chart injects SONAR_CLUSTER_NODE_IP from
-# the pod IP; otherwise autodiscover a global-scope address, preferring IPv4 then IPv6.
+# This application node's Hazelcast address (sonar.cluster.node.host): prefer the explicit
+# SONAR_CLUSTER_NODE_IP, else autodiscover a global-scope address (IPv4 then IPv6).
 resolve_node_ip() {
     if [[ -n "${SONAR_CLUSTER_NODE_IP:-}" ]]; then
         log "Cluster node IP set via SONAR_CLUSTER_NODE_IP=${SONAR_CLUSTER_NODE_IP}"
@@ -34,7 +34,7 @@ resolve_node_ip() {
 IP=$(resolve_node_ip)
 
 if [[ -z "${IP}" ]]; then
-    log "WARNING: no cluster node IP found; sonar.cluster.node.host will be unset and startup may fail."
+    log "WARNING: no application node IP found; sonar.cluster.node.host will be unset and startup may fail."
 fi
 
 declare -a sq_opts=()

--- a/commercial-editions/datacenter/app/run.sh
+++ b/commercial-editions/datacenter/app/run.sh
@@ -3,7 +3,39 @@
 set -euo pipefail
 
 HOSTNAME=$(hostname)
-IP=$(ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
+
+log() { printf '[run.sh] %s\n' "$*" >&2; }
+
+discover_ip() {
+    if [[ "${1}" == "6" ]]; then
+        ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    else
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    fi
+}
+
+# Resolve this node's cluster IP. In Kubernetes the Helm chart injects SONAR_CLUSTER_NODE_IP from
+# the pod IP; otherwise autodiscover a global-scope address, preferring IPv4 then IPv6.
+resolve_node_ip() {
+    if [[ -n "${SONAR_CLUSTER_NODE_IP:-}" ]]; then
+        log "Cluster node IP set via SONAR_CLUSTER_NODE_IP=${SONAR_CLUSTER_NODE_IP}"
+        printf '%s' "${SONAR_CLUSTER_NODE_IP}"
+        return
+    fi
+
+    log "SONAR_CLUSTER_NODE_IP not set; autodiscovering node IP (unreliable on multi-homed/dual-stack hosts)."
+    local discovered
+    discovered=$(discover_ip 4)
+    [[ -z "${discovered}" ]] && discovered=$(discover_ip 6)
+    log "Autodiscovered cluster node IP: ${discovered:-<none found>}"
+    printf '%s' "${discovered}"
+}
+
+IP=$(resolve_node_ip)
+
+if [[ -z "${IP}" ]]; then
+    log "WARNING: no cluster node IP found; sonar.cluster.node.host will be unset and startup may fail."
+fi
 
 declare -a sq_opts=()
 set_prop() {

--- a/commercial-editions/datacenter/search/run.sh
+++ b/commercial-editions/datacenter/search/run.sh
@@ -14,8 +14,8 @@ discover_ip() {
     fi
 }
 
-# Resolve this node's cluster IP. In Kubernetes the Helm chart injects SONAR_CLUSTER_NODE_IP from
-# the pod IP; otherwise autodiscover a global-scope address, preferring IPv4 then IPv6.
+# This search node's Elasticsearch address (sonar.cluster.node.search.host / .es.host): prefer the
+# explicit SONAR_CLUSTER_NODE_IP, else autodiscover a global-scope address (IPv4 then IPv6).
 resolve_node_ip() {
     if [[ -n "${SONAR_CLUSTER_NODE_IP:-}" ]]; then
         log "Cluster node IP set via SONAR_CLUSTER_NODE_IP=${SONAR_CLUSTER_NODE_IP}"
@@ -34,7 +34,7 @@ resolve_node_ip() {
 IP=$(resolve_node_ip)
 
 if [[ -z "${IP}" ]]; then
-    log "WARNING: no cluster node IP found; sonar.cluster.node.host will be unset and startup may fail."
+    log "WARNING: no search node IP found; sonar.cluster.node.search.host will be unset and startup may fail."
 fi
 
 declare -a sq_opts=()

--- a/commercial-editions/datacenter/search/run.sh
+++ b/commercial-editions/datacenter/search/run.sh
@@ -3,7 +3,39 @@
 set -euo pipefail
 
 HOSTNAME=$(hostname)
-IP=$(ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
+
+log() { printf '[run.sh] %s\n' "$*" >&2; }
+
+discover_ip() {
+    if [[ "${1}" == "6" ]]; then
+        ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    else
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    fi
+}
+
+# Resolve this node's cluster IP. In Kubernetes the Helm chart injects SONAR_CLUSTER_NODE_IP from
+# the pod IP; otherwise autodiscover a global-scope address, preferring IPv4 then IPv6.
+resolve_node_ip() {
+    if [[ -n "${SONAR_CLUSTER_NODE_IP:-}" ]]; then
+        log "Cluster node IP set via SONAR_CLUSTER_NODE_IP=${SONAR_CLUSTER_NODE_IP}"
+        printf '%s' "${SONAR_CLUSTER_NODE_IP}"
+        return
+    fi
+
+    log "SONAR_CLUSTER_NODE_IP not set; autodiscovering node IP (unreliable on multi-homed/dual-stack hosts)."
+    local discovered
+    discovered=$(discover_ip 4)
+    [[ -z "${discovered}" ]] && discovered=$(discover_ip 6)
+    log "Autodiscovered cluster node IP: ${discovered:-<none found>}"
+    printf '%s' "${discovered}"
+}
+
+IP=$(resolve_node_ip)
+
+if [[ -z "${IP}" ]]; then
+    log "WARNING: no cluster node IP found; sonar.cluster.node.host will be unset and startup may fail."
+fi
 
 declare -a sq_opts=()
 set_prop() {

--- a/example-compose-files/README.md
+++ b/example-compose-files/README.md
@@ -13,3 +13,15 @@ The health checks in these compose files rely on `curl`, but the currently relea
 - **Rebuild the search image locally** - the current Dockerfile already includes `curl`, so rebuilding from source will produce a working image
 
 We are aware of this issue and it will be resolved in the next official release.
+
+## Starting the DCE examples
+
+On a fresh database the first application node initializes the schema, so the application nodes must
+not start at the same time. The compose files enforce the order with `depends_on`, and the health
+checks give the first node time to migrate. Start the cluster with:
+
+```
+docker compose up -d --wait
+```
+
+`--wait` brings the nodes up in dependency order and waits for each to become healthy.

--- a/example-compose-files/sq-dce-custom-zip-postgres/README.md
+++ b/example-compose-files/sq-dce-custom-zip-postgres/README.md
@@ -47,7 +47,7 @@ You can access your SonarQube Server instance through the reverse proxy with thi
 
 | Variable | Default | Description |
 |---|---|---|
-| `USE_IPV6` | `false` | Set to `true` to run in IPv6 mode. Automatically sets the required JVM flags on all nodes. |
+| `USE_IPV6` | `false` | Set `true` to advertise IPv6 and set the IPv6 JVM flags on all nodes. Flip the single `x-use-ipv6` switch at the top of `docker-compose.yml`. |
 | `SONAR_WEB_CONTEXT` | _(empty)_ | Set to run SonarQube under a sub-path, e.g. `/sonarqube`. |
 
 ## Troubleshooting

--- a/example-compose-files/sq-dce-custom-zip-postgres/docker-compose.yml
+++ b/example-compose-files/sq-dce-custom-zip-postgres/docker-compose.yml
@@ -1,3 +1,6 @@
+# Single switch for the whole cluster: "true" advertises IPv6 and sets the IPv6 JVM flags; "false" is IPv4.
+x-use-ipv6: &use-ipv6 "false"
+
 services:
   sonarqube-1:
     hostname: "sonarqube-1"
@@ -41,7 +44,7 @@ services:
       SONAR_CLUSTER_HOSTS: "sonarqube"
       SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
       SONAR_WEB_CONTEXT: ${SONAR_WEB_CONTEXT:-}
-      USE_IPV6: ${USE_IPV6:-false}
+      USE_IPV6: *use-ipv6
       SONAR_CLUSTER_KUBERNETES: true
       VIRTUAL_HOST: sonarqube.dev.local
       VIRTUAL_PORT: 9000
@@ -73,6 +76,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      sonarqube-1:
+        condition: service_healthy
     networks:
       dual:
         ipv4_address: 192.168.3.92
@@ -92,7 +97,7 @@ services:
       SONAR_CLUSTER_HOSTS: "sonarqube"
       SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
       SONAR_WEB_CONTEXT: ${SONAR_WEB_CONTEXT:-}
-      USE_IPV6: ${USE_IPV6:-false}
+      USE_IPV6: *use-ipv6
       SONAR_CLUSTER_KUBERNETES: true
       VIRTUAL_HOST: sonarqube.dev.local
       VIRTUAL_PORT: 9000
@@ -128,7 +133,7 @@ services:
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2"
       SONAR_CLUSTER_ES_DISCOVERY_SEED_HOSTS: "search"
       SONAR_CLUSTER_NODE_NAME: "search-1"
-      USE_IPV6: ${USE_IPV6:-false}
+      USE_IPV6: *use-ipv6
     volumes:
       - search_data-1:/opt/sonarqube/data
       - sonarqube_logs:/opt/sonarqube/logs
@@ -169,7 +174,7 @@ services:
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2"
       SONAR_CLUSTER_ES_DISCOVERY_SEED_HOSTS: "search"
       SONAR_CLUSTER_NODE_NAME: "search-2"
-      USE_IPV6: ${USE_IPV6:-false}
+      USE_IPV6: *use-ipv6
     volumes:
       - search_data-2:/opt/sonarqube/data
       - sonarqube_logs:/opt/sonarqube/logs

--- a/example-compose-files/sq-dce-custom-zip-postgres/run-app.sh
+++ b/example-compose-files/sq-dce-custom-zip-postgres/run-app.sh
@@ -3,13 +3,47 @@
 set -euo pipefail
 
 HOSTNAME=$(hostname)
-USE_IPV6="${USE_IPV6:-false}"
-if [[ "${USE_IPV6}" == "true" ]]; then
-    IP=$(ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
-    export JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
-    export SONAR_WEB_JAVAADDITIONALOPTS="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
-else
-    IP=$(ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
+
+log() { printf '[run.sh] %s\n' "$*" >&2; }
+
+discover_ip() {
+    if [[ "${1}" == "6" ]]; then
+        ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    else
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    fi
+}
+
+# This application node's Hazelcast address (sonar.cluster.node.host): prefer the explicit
+# SONAR_CLUSTER_NODE_IP, else autodiscover, preferring IPv6 when USE_IPV6=true and IPv4 otherwise.
+resolve_node_ip() {
+    if [[ -n "${SONAR_CLUSTER_NODE_IP:-}" ]]; then
+        log "Cluster node IP set via SONAR_CLUSTER_NODE_IP=${SONAR_CLUSTER_NODE_IP}"
+        printf '%s' "${SONAR_CLUSTER_NODE_IP}"
+        return
+    fi
+
+    local primary=4 secondary=6
+    [[ "${USE_IPV6:-false}" == "true" ]] && { primary=6; secondary=4; }
+    log "SONAR_CLUSTER_NODE_IP not set; autodiscovering node IP (IPv${primary} then IPv${secondary})."
+    local discovered
+    discovered=$(discover_ip "${primary}")
+    [[ -z "${discovered}" ]] && discovered=$(discover_ip "${secondary}")
+    log "Autodiscovered cluster node IP: ${discovered:-<none found>}"
+    printf '%s' "${discovered}"
+}
+
+IP=$(resolve_node_ip)
+
+if [[ -z "${IP}" ]]; then
+    log "WARNING: no application node IP found; sonar.cluster.node.host will be unset and startup may fail."
+fi
+
+# When USE_IPV6 is enabled, tell the JVM to prefer IPv6 for SonarQube's own sockets.
+if [[ "${USE_IPV6:-false}" == "true" ]]; then
+    ipv6_jvm_opts="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
+    export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} ${ipv6_jvm_opts}"
+    export SONAR_WEB_JAVAADDITIONALOPTS="${SONAR_WEB_JAVAADDITIONALOPTS:-} ${ipv6_jvm_opts}"
 fi
 
 declare -a sq_opts=()

--- a/example-compose-files/sq-dce-custom-zip-postgres/run-search.sh
+++ b/example-compose-files/sq-dce-custom-zip-postgres/run-search.sh
@@ -3,13 +3,47 @@
 set -euo pipefail
 
 HOSTNAME=$(hostname)
-USE_IPV6="${USE_IPV6:-false}"
-if [[ "${USE_IPV6}" == "true" ]]; then
-    IP=$(ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
-    export JAVA_TOOL_OPTIONS="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
-    export SONAR_SEARCH_JAVAADDITIONALOPTS="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
-else
-    IP=$(ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
+
+log() { printf '[run.sh] %s\n' "$*" >&2; }
+
+discover_ip() {
+    if [[ "${1}" == "6" ]]; then
+        ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    else
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    fi
+}
+
+# This search node's Elasticsearch address (sonar.cluster.node.search.host / .es.host): prefer the
+# explicit SONAR_CLUSTER_NODE_IP, else autodiscover, preferring IPv6 when USE_IPV6=true and IPv4 otherwise.
+resolve_node_ip() {
+    if [[ -n "${SONAR_CLUSTER_NODE_IP:-}" ]]; then
+        log "Cluster node IP set via SONAR_CLUSTER_NODE_IP=${SONAR_CLUSTER_NODE_IP}"
+        printf '%s' "${SONAR_CLUSTER_NODE_IP}"
+        return
+    fi
+
+    local primary=4 secondary=6
+    [[ "${USE_IPV6:-false}" == "true" ]] && { primary=6; secondary=4; }
+    log "SONAR_CLUSTER_NODE_IP not set; autodiscovering node IP (IPv${primary} then IPv${secondary})."
+    local discovered
+    discovered=$(discover_ip "${primary}")
+    [[ -z "${discovered}" ]] && discovered=$(discover_ip "${secondary}")
+    log "Autodiscovered cluster node IP: ${discovered:-<none found>}"
+    printf '%s' "${discovered}"
+}
+
+IP=$(resolve_node_ip)
+
+if [[ -z "${IP}" ]]; then
+    log "WARNING: no search node IP found; sonar.cluster.node.search.host will be unset and startup may fail."
+fi
+
+# When USE_IPV6 is enabled, tell the JVM to prefer IPv6 for SonarQube's own sockets.
+if [[ "${USE_IPV6:-false}" == "true" ]]; then
+    ipv6_jvm_opts="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
+    export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} ${ipv6_jvm_opts}"
+    export SONAR_SEARCH_JAVAADDITIONALOPTS="${SONAR_SEARCH_JAVAADDITIONALOPTS:-} ${ipv6_jvm_opts}"
 fi
 
 declare -a sq_opts=()

--- a/example-compose-files/sq-dce-postgres/docker-compose.yml
+++ b/example-compose-files/sq-dce-postgres/docker-compose.yml
@@ -1,14 +1,13 @@
 services:
-  sonarqube:
-    deploy:
-      replicas: 3
+  app-1:
     healthcheck:
       test: curl -s http://localhost:9000/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'
       interval: 25s
       timeout: 1s
       retries: 3
-      start_period: 55s
+      start_period: 240s
     image: sonarqube:datacenter-app
+    hostname: "app-1"
     read_only: true
     depends_on:
       search-1:
@@ -20,7 +19,8 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.31
     cpus: 0.5
     mem_limit: 4096M
     mem_reservation: 4096M
@@ -29,9 +29,96 @@ services:
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
       SONAR_WEB_PORT: 9000
+      # Advertise this node's address explicitly instead of relying on autodiscovery.
+      SONAR_CLUSTER_NODE_IP: "192.168.16.31"
       SONAR_CLUSTER_SEARCH_HOSTS: "search-1,search-2,search-3"
-      SONAR_CLUSTER_HOSTS: "sonarqube"
-      SONAR_CLUSTER_KUBERNETES: true
+      SONAR_CLUSTER_HOSTS: "192.168.16.31,192.168.16.32,192.168.16.33"
+      SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
+      VIRTUAL_HOST: sonarqube.dev.local
+      VIRTUAL_PORT: 9000
+    volumes:
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+      - sonarqube_temp:/opt/sonarqube/temp
+      - /opt/sonarqube/data
+  app-2:
+    healthcheck:
+      test: curl -s http://localhost:9000/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'
+      interval: 25s
+      timeout: 1s
+      retries: 3
+      start_period: 240s
+    image: sonarqube:datacenter-app
+    hostname: "app-2"
+    read_only: true
+    depends_on:
+      search-1:
+        condition: service_healthy
+      search-2:
+        condition: service_healthy
+      search-3:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      app-1:
+        condition: service_healthy
+    networks:
+      sonar:
+        ipv4_address: 192.168.16.32
+    cpus: 0.5
+    mem_limit: 4096M
+    mem_reservation: 4096M
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+      SONAR_WEB_PORT: 9000
+      SONAR_CLUSTER_NODE_IP: "192.168.16.32"
+      SONAR_CLUSTER_SEARCH_HOSTS: "search-1,search-2,search-3"
+      SONAR_CLUSTER_HOSTS: "192.168.16.31,192.168.16.32,192.168.16.33"
+      SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
+      VIRTUAL_HOST: sonarqube.dev.local
+      VIRTUAL_PORT: 9000
+    volumes:
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+      - sonarqube_temp:/opt/sonarqube/temp
+      - /opt/sonarqube/data
+  app-3:
+    healthcheck:
+      test: curl -s http://localhost:9000/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'
+      interval: 25s
+      timeout: 1s
+      retries: 3
+      start_period: 240s
+    image: sonarqube:datacenter-app
+    hostname: "app-3"
+    read_only: true
+    depends_on:
+      search-1:
+        condition: service_healthy
+      search-2:
+        condition: service_healthy
+      search-3:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      app-1:
+        condition: service_healthy
+    networks:
+      sonar:
+        ipv4_address: 192.168.16.33
+    cpus: 0.5
+    mem_limit: 4096M
+    mem_reservation: 4096M
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+      SONAR_WEB_PORT: 9000
+      SONAR_CLUSTER_NODE_IP: "192.168.16.33"
+      SONAR_CLUSTER_SEARCH_HOSTS: "search-1,search-2,search-3"
+      SONAR_CLUSTER_HOSTS: "192.168.16.31,192.168.16.32,192.168.16.33"
       SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
       VIRTUAL_HOST: sonarqube.dev.local
       VIRTUAL_PORT: 9000
@@ -51,11 +138,13 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.21
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_CLUSTER_NODE_IP: "192.168.16.21"
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2,search-3"
       SONAR_CLUSTER_NODE_NAME: "search-1"
     volumes:
@@ -82,11 +171,13 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.22
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_CLUSTER_NODE_IP: "192.168.16.22"
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2,search-3"
       SONAR_CLUSTER_NODE_NAME: "search-2"
     volumes:
@@ -113,11 +204,13 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.23
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_CLUSTER_NODE_IP: "192.168.16.23"
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2,search-3"
       SONAR_CLUSTER_NODE_NAME: "search-3"
     volumes:
@@ -141,7 +234,7 @@ services:
       timeout: 5s
       retries: 5
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      - sonar
     environment:
       POSTGRES_USER: sonar
       POSTGRES_PASSWORD: sonar
@@ -156,24 +249,18 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./unrestricted_client_body_size.conf:/etc/nginx/conf.d/unrestricted_client_body_size.conf:ro
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      - sonar
       - sonar-public
 
 networks:
   sonar-public:
     driver: bridge
-  ipv4:
+  sonar:
     driver: bridge
-    enable_ipv6: false
-  dual:
-    driver: bridge
-    enable_ipv6: true
     ipam:
       config:
-        - subnet: "192.168.3.0/24"
-          gateway: "192.168.3.1"
-        - subnet: "2001:db8:3::/64"
-          gateway: "2001:db8:3::1"
+        - subnet: "192.168.16.0/24"
+          gateway: "192.168.16.1"
 
 volumes:
   sonarqube_extensions:

--- a/example-compose-files/sq-dce-with-mcp-postgres/docker-compose.yml
+++ b/example-compose-files/sq-dce-with-mcp-postgres/docker-compose.yml
@@ -1,7 +1,5 @@
 services:
-  sonarqube:
-    deploy:
-      replicas: 2
+  app-1:
     healthcheck:
       test: curl -s http://localhost:9000/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'
       interval: 25s
@@ -9,6 +7,7 @@ services:
       retries: 3
       start_period: 240s
     image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-datacenter-app}
+    hostname: "app-1"
     read_only: true
     depends_on:
       search-1:
@@ -20,7 +19,10 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.31
+        aliases:
+          - sonarqube
     cpus: 0.5
     mem_limit: 4096M
     mem_reservation: 4096M
@@ -29,9 +31,58 @@ services:
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
       SONAR_WEB_PORT: 9000
+      # Advertise this node's address explicitly instead of relying on autodiscovery.
+      SONAR_CLUSTER_NODE_IP: "192.168.16.31"
       SONAR_CLUSTER_SEARCH_HOSTS: "search-1,search-2,search-3"
-      SONAR_CLUSTER_HOSTS: "sonarqube"
-      SONAR_CLUSTER_KUBERNETES: true
+      SONAR_CLUSTER_HOSTS: "192.168.16.31,192.168.16.32"
+      SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
+      SONAR_MCP_ENABLED: "true"
+      SONAR_MCP_SERVERURL: "http://mcp:8080"
+      SONAR_MCP_HEALTHCHECKINTERVAL: "30"
+      VIRTUAL_HOST: sonarqube.dev.local
+      VIRTUAL_PORT: 9000
+    volumes:
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+      - sonarqube_temp:/opt/sonarqube/temp
+      - /opt/sonarqube/data
+  app-2:
+    healthcheck:
+      test: curl -s http://localhost:9000/api/system/status | grep -q -e '"status":"UP"' -e '"status":"DB_MIGRATION_NEEDED"' -e '"status":"DB_MIGRATION_RUNNING"'
+      interval: 25s
+      timeout: 1s
+      retries: 3
+      start_period: 240s
+    image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-datacenter-app}
+    hostname: "app-2"
+    read_only: true
+    depends_on:
+      search-1:
+        condition: service_healthy
+      search-2:
+        condition: service_healthy
+      search-3:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      app-1:
+        condition: service_healthy
+    networks:
+      sonar:
+        ipv4_address: 192.168.16.32
+        aliases:
+          - sonarqube
+    cpus: 0.5
+    mem_limit: 4096M
+    mem_reservation: 4096M
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+      SONAR_WEB_PORT: 9000
+      SONAR_CLUSTER_NODE_IP: "192.168.16.32"
+      SONAR_CLUSTER_SEARCH_HOSTS: "search-1,search-2,search-3"
+      SONAR_CLUSTER_HOSTS: "192.168.16.31,192.168.16.32"
       SONAR_AUTH_JWTBASE64HS256SECRET: "dZ0EB0KxnF++nr5+4vfTCaun/eWbv6gOoXodiAMqcFo="
       SONAR_MCP_ENABLED: "true"
       SONAR_MCP_SERVERURL: "http://mcp:8080"
@@ -54,11 +105,13 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.21
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_CLUSTER_NODE_IP: "192.168.16.21"
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2,search-3"
       SONAR_CLUSTER_NODE_NAME: "search-1"
     volumes:
@@ -85,11 +138,13 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.22
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_CLUSTER_NODE_IP: "192.168.16.22"
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2,search-3"
       SONAR_CLUSTER_NODE_NAME: "search-2"
     volumes:
@@ -116,11 +171,13 @@ services:
       db:
         condition: service_healthy
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      sonar:
+        ipv4_address: 192.168.16.23
     environment:
       SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
       SONAR_JDBC_USERNAME: sonar
       SONAR_JDBC_PASSWORD: sonar
+      SONAR_CLUSTER_NODE_IP: "192.168.16.23"
       SONAR_CLUSTER_ES_HOSTS: "search-1,search-2,search-3"
       SONAR_CLUSTER_NODE_NAME: "search-3"
     volumes:
@@ -144,7 +201,7 @@ services:
       timeout: 5s
       retries: 5
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      - sonar
     environment:
       POSTGRES_USER: sonar
       POSTGRES_PASSWORD: sonar
@@ -157,7 +214,9 @@ services:
     hostname: mcp
     container_name: sonarqube-mcp
     depends_on:
-      sonarqube:
+      app-1:
+        condition: service_healthy
+      app-2:
         condition: service_healthy
     environment:
       STORAGE_PATH: /data
@@ -170,12 +229,14 @@ services:
     ports:
       - "8080:8080"
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      - sonar
 
   proxy:
     image: jwilder/nginx-proxy
     depends_on:
-      sonarqube:
+      app-1:
+        condition: service_healthy
+      app-2:
         condition: service_healthy
     ports:
       - "80:80"
@@ -183,24 +244,18 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./unrestricted_client_body_size.conf:/etc/nginx/conf.d/unrestricted_client_body_size.conf:ro
     networks:
-      - ${NETWORK_TYPE:-ipv4}
+      - sonar
       - sonar-public
 
 networks:
   sonar-public:
     driver: bridge
-  ipv4:
+  sonar:
     driver: bridge
-    enable_ipv6: false
-  dual:
-    driver: bridge
-    enable_ipv6: true
     ipam:
       config:
-        - subnet: "192.168.3.0/24"
-          gateway: "192.168.3.1"
-        - subnet: "2001:db8:3::/64"
-          gateway: "2001:db8:3::1"
+        - subnet: "192.168.16.0/24"
+          gateway: "192.168.16.1"
 
 volumes:
   sonarqube_extensions:


### PR DESCRIPTION
## Testing

The change affects DCE cluster node-address resolution (app + search entrypoints), exercised by deploying DCE and forming the Hazelcast + Elasticsearch cluster over each IP family. The single-node image, built from this same branch, was deployed alongside to confirm no regression.

### Functional matrix — local Kubernetes (kind)

Deployed, formed the cluster, confirmed the web endpoint served over the cluster's IP family, and ran a **real project analysis (scanner → server, Compute Engine task `SUCCESS`, `ncloc > 0`)** for every cell below.

| | IPv4 | IPv6-only | Dual-stack |
|---|---|---|---|
| **DCE** | ✅ | ✅ | ✅ |
| **Single-node** | ✅ | ✅ | ✅ |

Run on three server versions — **2025.4.7**, **2026.1.3**, and **2026.3.1**. All cells passed.

### Real infrastructure — AWS EKS, single-stack IPv6 (DCE)

| Check | Result |
|---|---|
| Multi-host CNI over IPv6 (Hazelcast + Elasticsearch form across nodes over VPC IPv6) | ✅ |
| External IPv6 egress (source IPv6 preserved) | ✅ |
| External IPv6 ingress (external IPv6 client → HTTP 200, `status: UP`) | ✅ |

### Notes

- The `run.sh` node-address resolution applies to DCE only — single-node editions have no cluster to form and no node address to resolve, so their entrypoints and the Java base image are unaffected (deployed only to confirm no regression).
- The autodiscovery path was verified to fall through IPv4 → IPv6 correctly under `set -e` (no early exit on a no-match).


----
## Summary by Gitar

- **Cluster IP resolution:**
  - Added `resolve_node_ip` function to prioritize `SONAR_CLUSTER_NODE_IP` over autodiscovery.
  - Updated autodiscovery logic in `run.sh` scripts to support IPv4 with IPv6 fallback.
- **Docker Compose infrastructure:**
  - Standardized all DCE examples to use a single `sonar` bridge network.
  - Added explicit `SONAR_CLUSTER_NODE_IP` and increased `start_period` in health checks across all example configurations.

<sub>This will update automatically on new commits.</sub>