### PR TITLE
SONAR-24340 Resolve DCE cluster node IP for IPv4 and IPv6

### DIFF
--- a/commercial-editions/datacenter/app/run.sh
+++ b/commercial-editions/datacenter/app/run.sh
@@ -8,7 +8,9 @@ log() { printf '[run.sh] %s\n' "$*" >&2; }
 
 discover_ip() {
     if [[ "${1}" == "4" ]]; then
-        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+        # Skip 169.254.0.0/16: link-local per RFC 3927 but promoted to scope global
+        # by some CNIs (e.g. AWS VPC CNI on IPv6-only EKS for IPv4 egress interop).
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | cut -d \/ -f 1 | grep -v '^169\.254\.' | head -n 1 || true
     else
         ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
     fi

--- a/commercial-editions/datacenter/app/run.sh
+++ b/commercial-editions/datacenter/app/run.sh
@@ -3,7 +3,35 @@
 set -euo pipefail
 
 HOSTNAME=$(hostname)
-IP=$(ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
+
+log() { printf '[run.sh] %s\n' "$*" >&2; }
+
+discover_ip() {
+    if [[ "${1}" == "4" ]]; then
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    else
+        ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    fi
+}
+
+# Resolve this node's cluster address: prefer the explicit SONAR_CLUSTER_NODE_HOST, else autodiscover
+# a global-scope address (IPv4 then IPv6).
+resolve_node_ip() {
+    if [[ -n "${SONAR_CLUSTER_NODE_HOST:-}" ]]; then
+        log "Cluster node host set via SONAR_CLUSTER_NODE_HOST=${SONAR_CLUSTER_NODE_HOST}"
+        printf '%s' "${SONAR_CLUSTER_NODE_HOST}"
+        return
+    fi
+
+    log "SONAR_CLUSTER_NODE_HOST not set; autodiscovering node address."
+    local discovered
+    discovered=$(discover_ip 4)
+    [[ -z "${discovered}" ]] && discovered=$(discover_ip 6)
+    log "Autodiscovered cluster node IP: ${discovered:-<none found>}"
+    printf '%s' "${discovered}"
+}
+
+IP=$(resolve_node_ip)
 
 declare -a sq_opts=()
 set_prop() {

--- a/commercial-editions/datacenter/search/run.sh
+++ b/commercial-editions/datacenter/search/run.sh
@@ -8,7 +8,9 @@ log() { printf '[run.sh] %s\n' "$*" >&2; }
 
 discover_ip() {
     if [[ "${1}" == "4" ]]; then
-        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+        # Skip 169.254.0.0/16: link-local per RFC 3927 but promoted to scope global
+        # by some CNIs (e.g. AWS VPC CNI on IPv6-only EKS for IPv4 egress interop).
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | cut -d \/ -f 1 | grep -v '^169\.254\.' | head -n 1 || true
     else
         ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
     fi

--- a/commercial-editions/datacenter/search/run.sh
+++ b/commercial-editions/datacenter/search/run.sh
@@ -3,7 +3,35 @@
 set -euo pipefail
 
 HOSTNAME=$(hostname)
-IP=$(ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1)
+
+log() { printf '[run.sh] %s\n' "$*" >&2; }
+
+discover_ip() {
+    if [[ "${1}" == "4" ]]; then
+        ip -4 address show scope global | grep inet | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    else
+        ip -6 address show scope global | grep inet6 | awk '{ print $2 }' | head -n 1 | cut -d \/ -f 1 || true
+    fi
+}
+
+# Resolve this node's cluster address: prefer the explicit SONAR_CLUSTER_NODE_HOST, else autodiscover
+# a global-scope address (IPv4 then IPv6).
+resolve_node_ip() {
+    if [[ -n "${SONAR_CLUSTER_NODE_HOST:-}" ]]; then
+        log "Cluster node host set via SONAR_CLUSTER_NODE_HOST=${SONAR_CLUSTER_NODE_HOST}"
+        printf '%s' "${SONAR_CLUSTER_NODE_HOST}"
+        return
+    fi
+
+    log "SONAR_CLUSTER_NODE_HOST not set; autodiscovering node address."
+    local discovered
+    discovered=$(discover_ip 4)
+    [[ -z "${discovered}" ]] && discovered=$(discover_ip 6)
+    log "Autodiscovered cluster node IP: ${discovered:-<none found>}"
+    printf '%s' "${discovered}"
+}
+
+IP=$(resolve_node_ip)
 
 declare -a sq_opts=()
 set_prop() {


### PR DESCRIPTION
----
## Summary by Gitar

- **Networking updates:**
  - Introduced `resolve_node_ip` function in `run.sh` scripts for both `app` and `search` services.
  - Added support for explicit node host configuration via `SONAR_CLUSTER_NODE_HOST` environment variable.
  - Implemented automatic fallback to discover global IPv4, then IPv6, addresses when `SONAR_CLUSTER_NODE_HOST` is unset.
- **Robustness improvements:**
  - Excluded `169.254.0.0/16` link-local addresses from IPv4 autodiscovery to prevent conflicts with AWS VPC CNI configurations.

<sub>This will update automatically on new commits.</sub>