### PR TITLE
SONAR-30823 Update MCP version to 1.22.0.3040

### DIFF
--- a/example-compose-files/sq-dce-with-mcp-postgres/docker-compose.yml
+++ b/example-compose-files/sq-dce-with-mcp-postgres/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       - postgresql:/var/lib/postgresql
 
   mcp:
-    image: sonarsource/sonarqube-mcp:${MCP_VERSION:-1.18.1.2664}
+    image: sonarsource/sonarqube-mcp:${MCP_VERSION:-1.22.0.3040}
     hostname: mcp
     container_name: sonarqube-mcp
     depends_on:

--- a/example-compose-files/sq-with-mcp-postgres/docker-compose.yml
+++ b/example-compose-files/sq-with-mcp-postgres/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - sonarnet
 
   mcp:
-    image: sonarsource/sonarqube-mcp:${MCP_VERSION:-1.18.1.2664}
+    image: sonarsource/sonarqube-mcp:${MCP_VERSION:-1.22.0.3040}
     hostname: mcp
     container_name: sonarqube-mcp
     depends_on:


### PR DESCRIPTION
## Summary
- Bump `sonarqube-mcp` default version from `1.18.1.2664` to `1.22.0.3040` in `sq-dce-with-mcp-postgres` and `sq-with-mcp-postgres` compose files

## Test plan
- [x] Verify MCP container starts correctly with the new image tag