### PR TITLE
REL-4802 Release SonarQube Server 2026.4.0

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -2,7 +2,7 @@
 # This file contains all version numbers and common configurations used across workflows
 
 versions:
-  current: "2026.3.1"
+  current: "2026.4.0"
   community_build: "26.7.0.124771"
 
 images:

--- a/commercial-editions/datacenter/app/Dockerfile
+++ b/commercial-editions/datacenter/app/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.3.1.123439
+ARG SONARQUBE_VERSION=2026.4.0.125547
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/datacenter/search/Dockerfile
+++ b/commercial-editions/datacenter/search/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.3.1.123439
+ARG SONARQUBE_VERSION=2026.4.0.125547
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/developer/Dockerfile
+++ b/commercial-editions/developer/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.3.1.123439
+ARG SONARQUBE_VERSION=2026.4.0.125547
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/enterprise/Dockerfile
+++ b/commercial-editions/enterprise/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.3.1.123439
+ARG SONARQUBE_VERSION=2026.4.0.125547
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2026.3.1-datacenter-app
+FROM sonarqube:2026.4.0-datacenter-app
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2026.3.1-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2026.4.0-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-app.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2026.3.1-datacenter-search
+FROM sonarqube:2026.4.0-datacenter-search
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2026.3.1-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2026.4.0-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-search.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/README.md
+++ b/example-compose-files/sq-dce-custom-zip-postgres/README.md
@@ -16,11 +16,11 @@ ls -al
 11:33 Dockerfile-search
 11:39 README
 11:37 docker-compose.yml
-11:33 sonarqube-datacenter-2026.3.1.123439.zip
+11:33 sonarqube-datacenter-2026.4.0.125547.zip
 11:33 unrestricted_client_body_size.conf
 ```
 
-You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2026.3.1.123439` or by changing the docker-compose file.
+You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2026.4.0.125547` or by changing the docker-compose file.
 
 You can then run this command to start the SonarQube Server instance:
 

--- a/example-compose-files/sq-dce-with-mcp-postgres/docker-compose.yml
+++ b/example-compose-files/sq-dce-with-mcp-postgres/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       timeout: 1s
       retries: 3
       start_period: 240s
-    image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-datacenter-app}
+    image: sonarqube:${SONARQUBE_VERSION:-2026.4.0-datacenter-app}
     read_only: true
     depends_on:
       search-1:
@@ -44,7 +44,7 @@ services:
       - sonarqube_temp:/opt/sonarqube/temp
       - /opt/sonarqube/data
   search-1:
-    image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-datacenter-search}
+    image: sonarqube:${SONARQUBE_VERSION:-2026.4.0-datacenter-search}
     read_only: true
     hostname: "search-1"
     cpus: 0.5
@@ -75,7 +75,7 @@ services:
         retries: 3
         start_period: 55s
   search-2:
-    image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-datacenter-search}
+    image: sonarqube:${SONARQUBE_VERSION:-2026.4.0-datacenter-search}
     read_only: true
     hostname: "search-2"
     cpus: 0.5
@@ -106,7 +106,7 @@ services:
         retries: 3
         start_period: 55s
   search-3:
-    image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-datacenter-search}
+    image: sonarqube:${SONARQUBE_VERSION:-2026.4.0-datacenter-search}
     read_only: true
     hostname: "search-3"
     cpus: 0.5

--- a/example-compose-files/sq-with-mcp-postgres/docker-compose.yml
+++ b/example-compose-files/sq-with-mcp-postgres/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sonarqube:
-    image: sonarqube:${SONARQUBE_VERSION:-2026.3.0-enterprise}
+    image: sonarqube:${SONARQUBE_VERSION:-2026.4.0-enterprise}
     hostname: sonarqube
     container_name: sonarqube
     read_only: true


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
    - Updated SonarQube Server version to `2026.4.0` across all Dockerfiles, configurations, and environment files.
- **Documentation:**
    - Updated `README.md` to reference the new version `2026.4.0.125547` for custom deployments.

<sub>This will update automatically on new commits.</sub>