### PR TITLE
REL-4795 Release SQS 2025.4.8

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -2,7 +2,7 @@
 # This file contains all version numbers and common configurations used across workflows
 
 versions:
-  current: "2025.4.7"
+  current: "2025.4.8"
 
 images:
   staging: "sonarsource/sonarqube"

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -21,7 +21,7 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/RequestReview@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/RequestReview@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -23,7 +23,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/commercial-editions/datacenter/app/Dockerfile
+++ b/commercial-editions/datacenter/app/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.4.7.123368
+ARG SONARQUBE_VERSION=2025.4.8.125717
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/datacenter/search/Dockerfile
+++ b/commercial-editions/datacenter/search/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.4.7.123368
+ARG SONARQUBE_VERSION=2025.4.8.125717
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/developer/Dockerfile
+++ b/commercial-editions/developer/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.4.7.123368
+ARG SONARQUBE_VERSION=2025.4.8.125717
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/enterprise/Dockerfile
+++ b/commercial-editions/enterprise/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2025.4.7.123368
+ARG SONARQUBE_VERSION=2025.4.8.125717
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2025.4.7-datacenter-app
+FROM sonarqube:2025.4.8-datacenter-app
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2025.4.7-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2025.4.8-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-app.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2025.4.7-datacenter-search
+FROM sonarqube:2025.4.8-datacenter-search
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2025.4.7-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2025.4.8-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-search.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/README.md
+++ b/example-compose-files/sq-dce-custom-zip-postgres/README.md
@@ -16,11 +16,11 @@ ls -al
 11:33 Dockerfile-search
 11:39 README
 11:37 docker-compose.yml
-11:33 sonarqube-datacenter-2025.4.7.123368.zip
+11:33 sonarqube-datacenter-2025.4.8.125717.zip
 11:33 unrestricted_client_body_size.conf
 ```
 
-You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2025.4.7.123368` or by changing the docker-compose file.
+You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2025.4.8.125717` or by changing the docker-compose file.
 
 You can then run this command to start the SonarQube Server instance:
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
    - Updated current version to `2025.4.8` in `.github/github_env.yaml`.
    - Updated `SONARQUBE_VERSION` and base images to `2025.4.8` across Dockerfiles and example configurations.
- **GitHub Actions:**
    - Updated `sonarsource/gh-action-lt-backlog` actions to use major version `v2` instead of specific commit SHAs.

<sub>This will update automatically on new commits.</sub>