### PR TITLE
REL-4794 Release SonarQube Server 2026.1.4

### DIFF
--- a/.github/github_env.yaml
+++ b/.github/github_env.yaml
@@ -2,7 +2,7 @@
 # This file contains all version numbers and common configurations used across workflows
 
 versions:
-  current: "2026.1.3"
+  current: "2026.1.4"
 
 images:
   staging: "sonarsource/sonarqube"

--- a/commercial-editions/datacenter/app/Dockerfile
+++ b/commercial-editions/datacenter/app/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.1.3.123084
+ARG SONARQUBE_VERSION=2026.1.4.125802
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/datacenter/search/Dockerfile
+++ b/commercial-editions/datacenter/search/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.1.3.123084
+ARG SONARQUBE_VERSION=2026.1.4.125802
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/developer/Dockerfile
+++ b/commercial-editions/developer/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.1.3.123084
+ARG SONARQUBE_VERSION=2026.1.4.125802
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/commercial-editions/enterprise/Dockerfile
+++ b/commercial-editions/enterprise/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG='en_US.UTF-8' \
 #
 # SonarQube setup
 #
-ARG SONARQUBE_VERSION=2026.1.3.123084
+ARG SONARQUBE_VERSION=2026.1.4.125802
 ARG SONARQUBE_ZIP_URL=https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONARQUBE_VERSION}.zip
 ENV DOCKER_RUNNING="true" \
     JAVA_HOME='/opt/java/openjdk' \

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-app
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2026.1.3-datacenter-app
+FROM sonarqube:2026.1.4-datacenter-app
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2026.1.3-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2026.1.4-datacenter-app --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-app.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
+++ b/example-compose-files/sq-dce-custom-zip-postgres/Dockerfile-search
@@ -9,7 +9,7 @@ RUN cd /opt; \
     unzip -q sonarqube.zip;
 
 
-FROM sonarqube:2026.1.3-datacenter-search
+FROM sonarqube:2026.1.4-datacenter-search
 ARG SONARQUBE_VERSION
 ENV SONAR_VERSION=${SONARQUBE_VERSION}
 
@@ -17,7 +17,7 @@ USER root
 
 RUN rm -rf /opt/sonarqube*;
 
-COPY --from=sonarqube:2026.1.3-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
+COPY --from=sonarqube:2026.1.4-datacenter-search --chown=root:root --chmod=555 ${SONARQUBE_HOME}/docker/sonar.sh ${SONARQUBE_HOME}/docker/
 COPY --chown=root:root --chmod=555 ./run-search.sh ${SONARQUBE_HOME}/docker/run.sh
 COPY --from=copier /opt/sonarqube-${SONARQUBE_VERSION} /opt/sonarqube
 

--- a/example-compose-files/sq-dce-custom-zip-postgres/README.md
+++ b/example-compose-files/sq-dce-custom-zip-postgres/README.md
@@ -16,11 +16,11 @@ ls -al
 11:33 Dockerfile-search
 11:39 README
 11:37 docker-compose.yml
-11:33 sonarqube-datacenter-2026.1.2.102418.zip
+11:33 sonarqube-datacenter-2026.1.4.125802.zip
 11:33 unrestricted_client_body_size.conf
 ```
 
-You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2026.1.2.102418` or by changing the docker-compose file.
+You need to specify the SonarQube Server version that will be used either with an export like this `export SONARQUBE_VERSION=2026.1.4.125802` or by changing the docker-compose file.
 
 You can then run this command to start the SonarQube Server instance:
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Version Updates:**
    - Bumped SonarQube version to `2026.1.4` across workflows, Dockerfiles, and documentation examples

<sub>This will update automatically on new commits.</sub>