### PR TITLE
[SONAR-31958] README update for marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,27 @@
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/a23fc7ba-23f0-489a-829d-ed88c0748521/Sonar_Logo_Dark%20Backgrounds.svg">
+    <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/82c13eba-d95c-4bb8-8007-7ce77c14e043/Sonar_Logo_Light%20Backgrounds.svg" alt="Sonar logo" width="400">
+  </picture>
+</p>
+
 # SonarQube Docker images
 
+<p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/19f97554-c5ec-4cf1-87f7-878c02a19702/SQ_Logo_Server_Dark%20Backgrounds.svg">
+    <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/4a785d22-7141-409d-95a2-695c42595f90/SQ_Logo_Server_Light%20Backgrounds.png" alt="SonarQube Server logo" width="400">
+  </picture>
+</p>
+
+Run a self-managed SonarQube instance in a container and make code quality and security analysis available to local and CI workflows.
+
 [![CI - Build and Test](https://github.com/SonarSource/docker-sonarqube/actions/workflows/push_and_pr.yml/badge.svg)](https://github.com/SonarSource/docker-sonarqube/actions/workflows/push_and_pr.yml) [![Quality Gate Status](https://next.sonarqube.com/sonarqube/api/project_badges/measure?project=SonarSource_docker-sonarqube_AYcnOvlJTpBOcQuGEdI5&metric=alert_status&token=sqb_352337cc82cd0ba5dd1026de82ff553dd511afc2)](https://next.sonarqube.com/sonarqube/dashboard?id=SonarSource_docker-sonarqube_AYcnOvlJTpBOcQuGEdI5)
+[![Docker pulls](https://img.shields.io/docker/pulls/library/sonarqube)](https://hub.docker.com/_/sonarqube)
+[![GitHub stars](https://img.shields.io/github/stars/SonarSource/docker-sonarqube?style=flat)](https://github.com/SonarSource/docker-sonarqube)
+[![License](https://img.shields.io/badge/license-LGPL--3.0-blue)](#license)
+[![Community forum](https://img.shields.io/badge/community-forum-blue)](https://community.sonarsource.com/)
 
 About this Repo
 -----------------
@@ -10,7 +30,23 @@ This is the Git repo of the official Docker image for [SonarQube](https://regist
 
 The full readme is generated over in [docker-library/docs](https://github.com/docker-library/docs), specifically in [docker-library/docs/sonarqube](https://github.com/docker-library/docs/tree/master/sonarqube).
 
-Sonar's [Clean Code solution](https://www.sonarsource.com/solutions/clean-code/) helps developers deliver high-quality, efficient code standards that benefit the entire team or organization.
+## What the image provides
+
+- Official SonarQube images for the Community Build and supported commercial editions.
+- Versioned tags for repeatable local, test, and production deployments.
+- A containerized SonarQube runtime that scanners can send analysis results to.
+- Configuration and tag guidance maintained through the Docker Official Images documentation.
+
+The image runs the same SonarQube analysis for developer-written and AI-generated code. Scanners analyze a project and send the results to the running SonarQube instance, where teams can review explainable findings and enforce quality gates.
+
+## The SonarQube product line
+
+- [SonarQube Community Build](https://www.sonarsource.com/products/sonarqube/server/), the open-source server provided by this image.
+- [SonarQube Server](https://www.sonarsource.com/products/sonarqube/server/), the self-managed product with additional capabilities.
+- [SonarQube Cloud](https://www.sonarsource.com/products/sonarqube/cloud/), the hosted SonarQube service.
+- [SonarQube for IDE](https://www.sonarsource.com/products/sonarqube/ide/), real-time analysis while you write or generate code.
+- [SonarQube MCP Server](https://github.com/SonarSource/sonarqube-mcp-server), bringing SonarQube analysis into AI agent workflows.
+- [SonarQube CLI](https://docs.sonarsource.com/sonarqube-cli), running analysis from the command line.
 
 
 Have Questions or Feedback?


### PR DESCRIPTION
## Summary

This PR makes a focused README marketing update:

- adds responsive Sonar and SonarQube Server logos for GitHub light and dark modes
- adds a concise repository introduction, useful artifact/community badges, an image-capability summary, and SonarQube product-family navigation
- removes the retired Clean Code marketing paragraph

The repository's existing image documentation, technical instructions, support and contribution policies, and licensing are otherwise preserved.

## Review guidance

These changes were prepared automatically using the [shared README guidelines](https://github.com/SonarSource/sonar-readme-updates/blob/readme-updates/README-guidelines.md).

Please review the diff carefully for repository-specific and product-marketing accuracy, verify the logos in GitHub light and dark modes, and confirm that all required checks pass.

## Merge ownership

If the changes are accurate and all required checks pass, please have a CODEOWNER merge this PR when you are ready. The rollout author will not merge it because the repository owners are best placed to assess repository-specific checks and any build impact.

If a check fails or a correction is needed, please leave the PR unmerged and add a review comment.

## Validation

- reconciled with `master` at `886f9480f4a9caf83de23784e11aa054cc3ad7f5`
- confirmed that the existing About, support, contribution, and licence text remains unchanged
- verified the new links and CDN-hosted light/dark logo URLs
- deliberately excluded the earlier proposed Docker quickstart and all technical or policy rewrites

This is a documentation-only change and does not modify runtime code.

## Tracking

Jira: [SONAR-31958](https://sonarsource.atlassian.net/browse/SONAR-31958)


[SONAR-31958]: https://sonarsource.atlassian.net/browse/SONAR-31958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
